### PR TITLE
add hg to hg-bulk getters

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -572,6 +572,13 @@ HG_Finalize(hg_class_t *hg_class)
 }
 
 /*---------------------------------------------------------------------------*/
+hg_bulk_class_t *
+HG_Get_bulk_class(hg_class_t *hg_class)
+{
+    return HG_Core_get_bulk_class(hg_class);
+}
+
+/*---------------------------------------------------------------------------*/
 hg_context_t *
 HG_Context_create(hg_class_t *hg_class)
 {
@@ -583,6 +590,13 @@ hg_return_t
 HG_Context_destroy(hg_context_t *context)
 {
     return HG_Core_context_destroy(context);
+}
+
+/*---------------------------------------------------------------------------*/
+hg_bulk_context_t *
+HG_Get_bulk_context(hg_context_t *hg_context)
+{
+    return HG_Core_get_bulk_context(hg_context);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -79,6 +79,21 @@ HG_Finalize(
         );
 
 /**
+ * Retrieve the Mercury bulk class instance from the given Mercury class.
+ * Note that HG_Bulk_finalize should *not* be called on the returned
+ * instance if the bulk class is internal to the input class (that is, NULL
+ * was passed as the bulk class to HG_Init).
+ *
+ * \param hg_class [IN] HG class
+ *
+ * \return The corresponding bulk class
+ */
+HG_EXPORT hg_bulk_class_t *
+HG_Get_bulk_class(
+        hg_class_t *hg_class
+        );
+
+/**
  * Create a new context. Must be destroyed by calling HG_Context_destroy().
  *
  * \param hg_class [IN]         pointer to HG class
@@ -100,6 +115,21 @@ HG_Context_create(
 HG_EXPORT hg_return_t
 HG_Context_destroy(
         hg_context_t *context
+        );
+
+/**
+ * Retrieve the Mercury bulk context instance from the given Mercury context.
+ * Note that HG_Bulk_context_destroy should *not* be called on the returned
+ * context if the bulk context is internal to the input context (in the current
+ * API, this is always the case, but may not be in future revisions).
+ *
+ * \param hg_context [IN] HG context
+ *
+ * \return The corresponding bulk context
+ */
+HG_EXPORT hg_bulk_context_t *
+HG_Get_bulk_context(
+        hg_context_t *hg_context
         );
 
 /**

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1853,6 +1853,18 @@ done:
 }
 
 /*---------------------------------------------------------------------------*/
+hg_bulk_class_t *
+HG_Core_get_bulk_class(hg_class_t *hg_class)
+{
+    if (!hg_class) {
+        HG_LOG_ERROR("NULL class");
+        return NULL;
+    }
+    else
+        return hg_class->bulk_class;
+}
+
+/*---------------------------------------------------------------------------*/
 hg_context_t *
 HG_Core_context_create(hg_class_t *hg_class)
 {
@@ -1996,6 +2008,18 @@ HG_Core_context_destroy(hg_context_t *context)
 
 done:
     return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+hg_bulk_context_t *
+HG_Core_get_bulk_context(hg_context_t *hg_context)
+{
+    if (!hg_context) {
+        HG_LOG_ERROR("NULL context");
+        return NULL;
+    }
+    else
+        return hg_context->bulk_context;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -51,6 +51,14 @@ HG_Core_finalize(
         );
 
 /**
+ * See HG_Get_bulk_class.
+ */
+HG_EXPORT hg_bulk_class_t *
+HG_Core_get_bulk_class(
+        hg_class_t *hg_class
+        );
+
+/**
  * Create a new context. Must be destroyed by calling HG_Core_context_destroy().
  *
  * \param hg_class [IN]         pointer to HG class
@@ -72,6 +80,14 @@ HG_Core_context_create(
 HG_EXPORT hg_return_t
 HG_Core_context_destroy(
         hg_context_t *context
+        );
+
+/**
+ * See HG_Get_bulk_context.
+ */
+HG_EXPORT hg_bulk_context_t *
+HG_Core_get_bulk_context(
+        hg_context_t *hg_context
         );
 
 /**


### PR DESCRIPTION
Convenience function for getting a bulk class from a mercury class. Especially useful when using an implicit bulk class (e.g. passing HG_BULK_NULL to HG_Init).