### PR TITLE
avoid calling lookup_wait in threaded example

### DIFF
--- a/Examples/src/example_rpc_engine.c
+++ b/Examples/src/example_rpc_engine.c
@@ -90,11 +90,11 @@ hg_class_t* hg_engine_get_class(void)
     return(hg_class);
 }
 
-void hg_engine_addr_lookup(const char* name, na_addr_t* addr)
+void hg_engine_addr_lookup(const char* name, na_cb_t cb, void *arg)
 {
     na_return_t ret;
 
-    ret = NA_Addr_lookup_wait(network_class, name, addr);
+    ret = NA_Addr_lookup(network_class, na_context, cb, arg, name, NA_OP_ID_IGNORE);
     assert(ret == NA_SUCCESS);
 
     return;

--- a/Examples/src/example_rpc_engine.h
+++ b/Examples/src/example_rpc_engine.h
@@ -24,7 +24,7 @@
 void hg_engine_init(na_bool_t listen, const char* local_addr);
 void hg_engine_finalize(void);
 hg_class_t* hg_engine_get_class(void);
-void hg_engine_addr_lookup(const char* name, na_addr_t* addr);
+void hg_engine_addr_lookup(const char* name, na_cb_t cb, void *arg);
 void hg_engine_create_handle(na_addr_t addr, hg_id_t id,
     hg_handle_t *handle);
 


### PR DESCRIPTION
- The example program uses a dedicated thread to call HG_Progress,
  which means that there will be contention if one of the other threads
  calls NA_Addr_lookup_wait() (which internally will attempt to drive NA
  progress on its own)
- Use asynchronous NA_Addr_lookup() instead