### PR TITLE
use short sends for req/response

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -103,8 +103,10 @@ struct hg_handle {
 
     void *in_buf;                       /* Input buffer */
     na_size_t in_buf_size;              /* Input buffer size */
+    na_size_t in_buf_used;              /* Amount of input buffer used */
     void *out_buf;                      /* Output buffer */
     na_size_t out_buf_size;             /* Output buffer size */
+    na_size_t out_buf_used;             /* Amount of output buffer used */
 
     na_op_id_t na_send_op_id;           /* Operation ID for send */
     na_op_id_t na_recv_op_id;           /* Operation ID for recv */
@@ -590,13 +592,14 @@ hg_core_get_header_request(struct hg_handle *hg_handle,
     struct hg_header_request *request_header)
 {
     hg_return_t ret = HG_SUCCESS;
+    hg_size_t extra_header_size;
 
     /* Initialize header with default values */
     hg_proc_header_request_init(0, HG_BULK_NULL, request_header);
 
     /* Decode request header */
     ret = hg_proc_header_request(hg_handle->in_buf, hg_handle->in_buf_size,
-            request_header, HG_DECODE, hg_handle->hg_info.hg_bulk_class);
+            request_header, HG_DECODE, hg_handle->hg_info.hg_bulk_class, &extra_header_size);
     if (ret != HG_SUCCESS) {
         HG_LOG_ERROR("Could not decode header");
         goto done;
@@ -1042,7 +1045,7 @@ hg_core_forward_na(struct hg_handle *hg_handle)
     /* And post the send message (input) */
     na_ret = NA_Msg_send_unexpected(hg_class->na_class,
             hg_class->na_context, hg_core_send_input_cb, hg_handle,
-            hg_handle->in_buf, hg_handle->in_buf_size,
+            hg_handle->in_buf, hg_handle->in_buf_used,
             hg_handle->hg_info.addr, hg_handle->tag,
             &hg_handle->na_send_op_id);
     if (na_ret != NA_SUCCESS) {
@@ -1112,7 +1115,7 @@ hg_core_respond_na(struct hg_handle *hg_handle, hg_cb_t callback, void *arg)
     /* Respond back */
     na_ret = NA_Msg_send_expected(hg_class->na_class, hg_class->na_context,
             hg_core_send_output_cb, hg_handle, hg_handle->out_buf,
-            hg_handle->out_buf_size, hg_handle->hg_info.addr,
+            hg_handle->out_buf_used, hg_handle->hg_info.addr,
             hg_handle->tag, &hg_handle->na_send_op_id);
     if (na_ret != NA_SUCCESS) {
         HG_LOG_ERROR("Could not post send for output buffer");
@@ -1174,10 +1177,11 @@ hg_core_recv_input_cb(const struct na_cb_info *callback_info)
     hg_handle->addr_mine = HG_TRUE; /* Address will be freed with handle */
     hg_handle->tag = callback_info->info.recv_unexpected.tag;
     if (callback_info->info.recv_unexpected.actual_buf_size
-            != hg_handle->in_buf_size) {
-        HG_LOG_ERROR("Buffer size and actual transfer size do not match");
+            > hg_handle->in_buf_size) {
+        HG_LOG_ERROR("Actual transfer size is too large for unexpected recv");
         goto done;
     }
+    hg_handle->in_buf_used = callback_info->info.recv_unexpected.actual_buf_size;
 
     /* Move handle from pending list to processing list */
     if (hg_core_pending_list_remove(hg_handle) != HG_SUCCESS) {
@@ -2295,12 +2299,13 @@ done:
 /*---------------------------------------------------------------------------*/
 hg_return_t
 HG_Core_forward(hg_handle_t handle, hg_cb_t callback, void *arg,
-    hg_bulk_t extra_in_handle)
+    hg_bulk_t extra_in_handle, hg_size_t size_to_send)
 {
     struct hg_handle *hg_handle = (struct hg_handle *) handle;
     struct hg_header_request request_header;
     hg_return_t (*hg_forward)(struct hg_handle *hg_handle);
     hg_return_t ret = HG_SUCCESS;
+    hg_size_t extra_header_size = 0;
 
     if (!hg_handle) {
         HG_LOG_ERROR("NULL handle");
@@ -2323,11 +2328,15 @@ HG_Core_forward(hg_handle_t handle, hg_cb_t callback, void *arg,
 
     /* Encode request header */
     ret = hg_proc_header_request(hg_handle->in_buf, hg_handle->in_buf_size,
-            &request_header, HG_ENCODE, hg_handle->hg_info.hg_bulk_class);
+            &request_header, HG_ENCODE, hg_handle->hg_info.hg_bulk_class,
+            &extra_header_size);
     if (ret != HG_SUCCESS) {
         HG_LOG_ERROR("Could not encode header");
         goto done;
     }
+
+    /* set the actual size of the msg that needs to be transmitted */
+    hg_handle->in_buf_used = size_to_send + extra_header_size;
 
     /* If addr is self, forward locally, otherwise send the encoded buffer
      * through NA and pre-post response */
@@ -2346,7 +2355,7 @@ done:
 /*---------------------------------------------------------------------------*/
 hg_return_t
 HG_Core_respond(hg_handle_t handle, hg_cb_t callback, void *arg,
-    hg_return_t ret_code)
+    hg_return_t ret_code, hg_size_t size_to_send)
 {
     struct hg_handle *hg_handle = (struct hg_handle *) handle;
     hg_return_t (*hg_respond)(struct hg_handle *hg_handle, hg_cb_t callback,
@@ -2372,6 +2381,9 @@ HG_Core_respond(hg_handle_t handle, hg_cb_t callback, void *arg,
         HG_LOG_ERROR("Could not encode header");
         goto done;
     }
+    
+    /* set the actual size of the msg that needs to be transmitted */
+    hg_handle->out_buf_used = size_to_send;
 
     /* If addr is self, forward locally, otherwise send the encoded buffer
      * through NA and pre-post response */

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -254,6 +254,7 @@ HG_Core_get_output(
  * \param callback [IN]         pointer to function callback
  * \param arg [IN]              pointer to data passed to callback
  * \param extra_in_handle [IN]  bulk handle to extra input buffer
+ * \param size_to_send [IN]     size of request to transmit
  *
  * \return HG_SUCCESS or corresponding HG error code
  */
@@ -262,7 +263,8 @@ HG_Core_forward(
         hg_handle_t handle,
         hg_cb_t callback,
         void *arg,
-        hg_bulk_t extra_in_handle
+        hg_bulk_t extra_in_handle,
+        hg_size_t size_to_send
         );
 
 /**
@@ -276,6 +278,7 @@ HG_Core_forward(
  * \param callback [IN]         pointer to function callback
  * \param arg [IN]              pointer to data passed to callback
  * \param ret_code [IN]         return code included in response
+ * \param size_to_send [IN]     amounto of data to send in response
  *
  * \return HG_SUCCESS or corresponding HG error code
  */
@@ -284,7 +287,8 @@ HG_Core_respond(
         hg_handle_t handle,
         hg_cb_t callback,
         void *arg,
-        hg_return_t ret_code
+        hg_return_t ret_code,
+        hg_size_t size_to_send
         );
 
 /**

--- a/src/mercury_proc.c
+++ b/src/mercury_proc.c
@@ -281,6 +281,28 @@ done:
 }
 
 /*---------------------------------------------------------------------------*/
+hg_size_t
+hg_proc_get_size_used(hg_proc_t proc)
+{
+    struct hg_proc *hg_proc = (struct hg_proc *) proc;
+    hg_size_t size = 0;
+
+    if (!hg_proc) {
+        HG_LOG_ERROR("Proc is not initialized");
+        goto done;
+    }
+
+    if(hg_proc->extra_buf.size > 0)
+        size = (hg_proc->proc_buf.size + hg_proc->extra_buf.size) - hg_proc->extra_buf.size_left;
+    else
+        size = hg_proc->proc_buf.size - hg_proc->proc_buf.size_left;
+
+done:
+    return size;
+
+}
+
+/*---------------------------------------------------------------------------*/
 hg_return_t
 hg_proc_set_size(hg_proc_t proc, hg_size_t req_buf_size)
 {
@@ -530,6 +552,7 @@ hg_proc_flush(hg_proc_t proc)
             goto done;
         }
     }
+
 
     /* Process checksum (TODO should that depend on the encoding method) */
     ret = hg_proc_raw(proc, base_checksum, checksum_size);

--- a/src/mercury_proc.h
+++ b/src/mercury_proc.h
@@ -138,6 +138,19 @@ hg_proc_get_size(
         );
 
 /**
+ * Get amount of buffer space that has actually been consumed
+ *
+ * \param proc [IN]             abstract processor object
+ *
+ * \return Non-negative size value
+ */
+HG_EXPORT hg_size_t
+hg_proc_get_size_used(
+        hg_proc_t proc
+        );
+
+
+/**
  * Request a new buffer size. This will modify the size of the buffer attached
  * to the processor or create an extra processing buffer.
  *

--- a/src/mercury_proc_header.c
+++ b/src/mercury_proc_header.c
@@ -74,7 +74,7 @@ hg_proc_header_response_init(struct hg_header_response *header)
 hg_return_t
 hg_proc_header_request(void *buf, size_t buf_size,
         struct hg_header_request *header, hg_proc_op_t op,
-        hg_bulk_class_t *bulk_class)
+        hg_bulk_class_t *bulk_class, hg_size_t *extra_header_size)
 {
     hg_uint32_t n_protocol, n_id, n_cookie;
     hg_uint16_t n_crc16;
@@ -84,6 +84,7 @@ hg_proc_header_request(void *buf, size_t buf_size,
 #endif
     hg_proc_t proc = HG_PROC_NULL;
     hg_return_t ret = HG_SUCCESS;
+    *extra_header_size = 0;
 
     if (buf_size < sizeof(struct hg_header_request)) {
         HG_LOG_ERROR("Invalid buffer size");
@@ -179,6 +180,7 @@ hg_proc_header_request(void *buf, size_t buf_size,
             HG_LOG_ERROR("Error in proc flush");
             goto done;
         }
+        *extra_header_size = hg_proc_get_size_used(proc);
     }
 
 done:

--- a/src/mercury_proc_header.h
+++ b/src/mercury_proc_header.h
@@ -129,13 +129,14 @@ hg_proc_header_response_init(struct hg_header_response *header);
  * \param header [IN/OUT]       pointer to header structure
  * \param op [IN]               operation type: HG_ENCODE / HG_DECODE
  * \param bulk_class [IN]       HG bulk class
+ * \param extra_header_size [OUT] bytes added beyond normal header size
  *
  * \return HG_SUCCESS or corresponding HG error code
  */
 HG_EXPORT hg_return_t
 hg_proc_header_request(void *buf, size_t buf_size,
         struct hg_header_request *header, hg_proc_op_t op,
-        hg_bulk_class_t *bulk_class);
+        hg_bulk_class_t *bulk_class, hg_size_t *extra_header_size);
 
 /**
  * Process private information for sending/receiving response.

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -2122,9 +2122,9 @@ na_bmi_complete(struct na_bmi_op_id *na_bmi_op_id)
             break;
         case NA_CB_RECV_EXPECTED:
             /* Check buf_size and actual_size */
-            if (na_bmi_op_id->info.recv_expected.actual_size !=
+            if (na_bmi_op_id->info.recv_expected.actual_size >
                     na_bmi_op_id->info.recv_expected.buf_size) {
-                NA_LOG_ERROR("Buffer size and actual transfer size do not match");
+                NA_LOG_ERROR("Expected recv size too large for buffer");
                 ret = NA_SIZE_ERROR;
                 goto done;
             }

--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -2003,9 +2003,9 @@ na_cci_complete(na_cci_addr_t *na_cci_addr, na_cci_op_id_t *na_cci_op_id, na_ret
 		break;
 	case NA_CB_RECV_EXPECTED:
 		/* Check buf_size and actual_size */
-		if (na_cci_op_id->info.recv_expected.actual_size !=
+		if (na_cci_op_id->info.recv_expected.actual_size >
 		    na_cci_op_id->info.recv_expected.buf_size) {
-			NA_LOG_ERROR("Buffer size and actual transfer size do not match");
+			NA_LOG_ERROR("Expected recv too large for buffer");
 			ret = NA_SIZE_ERROR;
 			goto out;
 		}

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -2568,8 +2568,8 @@ na_mpi_complete(struct na_mpi_op_id *na_mpi_op_id)
                 goto done;
             }
             if (na_mpi_op_id->info.recv_expected.actual_size
-                    != na_mpi_op_id->info.recv_expected.buf_size) {
-                NA_LOG_ERROR("Buffer size and actual transfer size do not match");
+                    > na_mpi_op_id->info.recv_expected.buf_size) {
+                NA_LOG_ERROR("Expected recv size too large for buffer");
                 ret = NA_SIZE_ERROR;
                 goto done;
             }


### PR DESCRIPTION
This makes Mercury use short sends for both requests and responses.  Rather than sending the full buffer that was pre-allocated to the maximum unexpected size reported by the NA transport, it only sends the portion of it that holds the encoded request or response struct and HG header.

For my example program with CCI/TCP on a loopback interface, this reduces the request/response sizes in bytes from 8988/8988 to 104/28.  I think this change will probably reduce RPC latency for all transports.

Fixes #68 