### PR TITLE
add hg_request_forward_cb convenience function

### DIFF
--- a/src/mercury_types.h
+++ b/src/mercury_types.h
@@ -63,7 +63,7 @@ typedef enum {
 } hg_proc_hash_t;
 
 /* Error return codes:
- * Functions return 0 for success or -HG_XXX_ERROR for failure */
+ * Functions return 0 for success or HG_XXX_ERROR for failure */
 typedef enum hg_return {
     HG_SUCCESS = 0,     /*!< operation succeeded */
     HG_NA_ERROR,        /*!< error in NA layer */
@@ -73,7 +73,8 @@ typedef enum hg_return {
     HG_NOMEM_ERROR,     /*!< no memory error */
     HG_PROTOCOL_ERROR,  /*!< protocol does not match */
     HG_NO_MATCH,        /*!< no function match */
-    HG_CHECKSUM_ERROR   /*!< checksum error */
+    HG_CHECKSUM_ERROR,  /*!< checksum error */
+    HG_OTHER_ERROR      /*!< error from mercury_util or external to mercury */
 } hg_return_t;
 
 /* Callback operation type */

--- a/src/util/mercury_request.c
+++ b/src/util/mercury_request.c
@@ -238,6 +238,14 @@ hg_request_waitall(int count, hg_request_t *request[], unsigned int timeout,
 }
 
 /*---------------------------------------------------------------------------*/
+hg_return_t
+hg_request_complete_cb(const struct hg_cb_info *cb_info)
+{
+    int ret = hg_request_complete(cb_info->arg);
+    return ret == HG_UTIL_SUCCESS ? HG_SUCCESS : HG_OTHER_ERROR;
+}
+
+/*---------------------------------------------------------------------------*/
 int
 hg_request_set_data(hg_request_t *request, void *data)
 {

--- a/src/util/mercury_request.h
+++ b/src/util/mercury_request.h
@@ -11,6 +11,7 @@
 #ifndef MERCURY_REQUEST_H
 #define MERCURY_REQUEST_H
 
+#include <mercury_types.h>
 #include "mercury_util_config.h"
 
 /**
@@ -135,6 +136,17 @@ hg_request_wait(hg_request_t *request, unsigned int timeout,
 HG_UTIL_EXPORT int
 hg_request_waitall(int count, hg_request_t *request[],  unsigned int timeout,
         unsigned int *flag);
+
+/**
+ * A convenience callback function to pass to HG calls when using
+ * hg_request. This function simply interprets the argument passed into
+ * the HG call as an hg_request_t and calls hg_request_complete on it.
+ *
+ * \return HG_SUCCESS if hg_request_complete returns HG_UTIL_SUCCESS,
+ *         HG_OTHER_ERROR otherwise
+ */
+HG_UTIL_EXPORT hg_return_t
+hg_request_complete_cb(const struct hg_cb_info *cb_info);
 
 /**
  * Attach user data to a specified request.


### PR DESCRIPTION
Simple function that should account for 90% of hg_request use cases (HG_Forward + hg_request_wait).

Also, noticed a doc error about returning -HG_XXX_ERROR, which doesn't seem to be done, and added an HG_OTHER_ERROR error type for errors outside the purview of mercury (such as mercury_util).