### PR TITLE
rearrange op-id store to avoid race

### DIFF
--- a/src/na/na.c
+++ b/src/na/na.c
@@ -1345,14 +1345,18 @@ NA_Put(na_class_t *na_class, na_context_t *context, na_cb_t callback, void *arg,
         goto done;
     }
 
+    /* NOTE: op must be set before the put rather than after - it's possible
+     * for progress/trigger to drop in and free op_id between the (immediate)
+     * completion of the underlying op and return of control to this function
+     */
+    if (op_id && op_id != NA_OP_ID_IGNORE) *op_id = na_op_id;
+
     ret = na_class->put(na_class, context, callback, arg, local_mem_handle,
             local_offset, remote_mem_handle, remote_offset, data_size,
             remote_addr, &na_op_id);
     if (ret != NA_SUCCESS) {
         goto done;
     }
-
-    if (op_id && op_id != NA_OP_ID_IGNORE) *op_id = na_op_id;
 
 done:
     return ret;


### PR DESCRIPTION
Made a quick fix to NA_Put to help mitigate the race condition in #96. It appears sufficient - tsan doesn't complain for the test case (it detects other things, though...), and I'm able to execute the program without the race corrupting glibc :).