### PR TITLE
update na_cci to use create_endpoint_at

### DIFF
--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -434,7 +434,7 @@ out:
 /*---------------------------------------------------------------------------*/
 static na_return_t
 na_cci_initialize(na_class_t * na_class, const struct na_info *na_info,
-    na_bool_t NA_UNUSED listen)
+    na_bool_t listen)
 {
     int rc = 0, i = 0;
     uint32_t caps = 0;
@@ -442,6 +442,7 @@ na_cci_initialize(na_class_t * na_class, const struct na_info *na_info,
     cci_endpoint_t *endpoint = NULL;
     char *uri = NULL;
     na_return_t ret = NA_SUCCESS;
+    char *string_port = NULL;
 
     /* Initialize CCI */
     rc = cci_init(CCI_ABI_VERSION, 0, &caps);
@@ -484,7 +485,23 @@ na_cci_initialize(na_class_t * na_class, const struct na_info *na_info,
     }
 
     /* Create an endpoint using the requested transport */
-    rc = cci_create_endpoint(device, 0, &endpoint, NULL);
+    if(!listen)
+    {
+       rc = cci_create_endpoint(device, 0, &endpoint, NULL);
+    }
+    else
+    {
+        /* In listen mode we honor the port description */
+        string_port = rindex(na_info->port_name, ':');
+        if(!string_port)
+        {
+            NA_LOG_ERROR("na_cci failed to find port description (portion of string address following :) in HG listen address.\n");
+           ret = NA_PROTOCOL_ERROR;
+           goto out;
+        }
+        string_port++;
+        rc = cci_create_endpoint_at(device, string_port, 0, &endpoint, NULL);
+    }
     if (rc) {
         NA_LOG_ERROR("cci_create_endpoint() failed with %s",
             cci_strerror(NULL, rc));


### PR DESCRIPTION
(repeat of previous pull request #95 which had to be closed because of a comedy of git mistakes)

This is the update to Mercury that will take advantage of CCI's new create_endpoint_at() API to honor port descriptions provided by Mercury as part of the host URI.  

The corresponding functionality is not released yet in CCI, just getting the Mercury side changes ready in this pull request.