### PR TITLE
rm unnecessary APPLE check for pc generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ install(
 #-----------------------------------------------------------------------------
 # For automake compatibility, also a provide a pkgconfig file
 #-----------------------------------------------------------------------------
-if(NOT WIN32 AND NOT APPLE)
+if(NOT WIN32)
   configure_file(
     ${MERCURY_SOURCE_DIR}/CMake/mercury.pc.in
     ${MERCURY_BINARY_DIR}/CMakeFiles/mercury.pc @ONLY


### PR DESCRIPTION
pkg-config works just fine on APPLE.

Also, does mercury really support windows??