### PR TITLE
Update mercury_error.h

### DIFF
--- a/src/mercury_error.h
+++ b/src/mercury_error.h
@@ -50,9 +50,9 @@
       fprintf(stdout, "\n");                                         \
   } while (0)
 #else
-  #define HG_LOG_ERROR
-  #define HG_LOG_DEBUG
-  #define HG_LOG_WARNING
+  #define HG_LOG_ERROR(...) (void)0
+  #define HG_LOG_DEBUG(...) (void)0
+  #define HG_LOG_WARNING(...) (void)0
 #endif
 
 #endif /* MERCURY_ERROR_H */


### PR DESCRIPTION
Users of Mercury that turn warnings to errors and use -Wall can't compile if verbose errors are disabled.  This fixes that by consuming the arguments in the macro.  The (void)0 allows a compiler to catch errors like this

if (...)
    HG_LOG_ERROR("Error Message") //missing semicolon
do_something_important();