### PR TITLE
[WIP] address parsing

### DIFF
--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -56,18 +56,18 @@ mark_as_advanced(MERCURY_TESTING_CORESIDENT)
 # (case where the NA plugin defines multiple protocols)
 #------------------------------------------------------------------------------
 if(NA_USE_BMI)
-  set(NA_BMI_TESTING_PROTOCOL "" CACHE STRING "Protocol(s) used for testing (e.g., tcp;ib).")
+  set(NA_BMI_TESTING_PROTOCOL "tcp" CACHE STRING "Protocol(s) used for testing (e.g., tcp;ib).")
   mark_as_advanced(NA_BMI_TESTING_PROTOCOL)
 endif()
 
 #Does not really make sense for MPI (so do not add an option for it)
-#if(NA_USE_MPI)
-#  set(NA_MPI_TESTING_PROTOCOL "" CACHE STRING "Protocol(s) used for testing (e.g., tcp;ib).")
-#  mark_as_advanced(NA_MPI_TESTING_PROTOCOL)
-#endif()
+if(NA_USE_MPI)
+  set(NA_MPI_TESTING_PROTOCOL "dynamic;static" CACHE STRING "Protocol(s) used for testing (e.g., dynamic;static).")
+  mark_as_advanced(NA_MPI_TESTING_PROTOCOL)
+endif()
 
 if(NA_USE_CCI)
-  set(NA_CCI_TESTING_PROTOCOL "" CACHE STRING "Protocol(s) used for testing (e.g., tcp;ib).")
+  set(NA_CCI_TESTING_PROTOCOL "tcp;sm" CACHE STRING "Protocol(s) used for testing (e.g., tcp;sm).")
   mark_as_advanced(NA_CCI_TESTING_PROTOCOL)
 endif()
 
@@ -131,22 +131,21 @@ macro(add_mercury_test_comm test_name comm protocol opt)
     set(test_args ${test_args} --${opt})
   endif()
 
-  # Dynamic client/server test
-  add_test(NAME "mercury_${full_test_name}"
-    COMMAND $<TARGET_FILE:mercury_test_driver>
-    --server $<TARGET_FILE:hg_test_server>
-    --client $<TARGET_FILE:hg_test_${test_name}> ${test_args}
-  )
-
   # Static client/server test
-  if(${comm} STREQUAL "mpi")
-    set(static_test_name ${full_test_name}_static)
+  if(${comm} STREQUAL "mpi" AND ${protocol} STREQUAL "static")
     set(static_test_args ${test_args} --static)
-    add_test(NAME "mercury_${static_test_name}"
+    add_test(NAME "mercury_${full_test_name}"
       COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1
       ${MPIEXEC_PREFLAGS} $<TARGET_FILE:hg_test_server> ${MPIEXEC_POSTFLAGS}
       ${static_test_args} : ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
       ${MPIEXEC_PREFLAGS} $<TARGET_FILE:hg_test_${test_name}> ${static_test_args}
+    )
+  else()
+    # Dynamic client/server test
+    add_test(NAME "mercury_${full_test_name}"
+      COMMAND $<TARGET_FILE:mercury_test_driver>
+      --server $<TARGET_FILE:hg_test_server>
+      --client $<TARGET_FILE:hg_test_${test_name}> ${test_args}
     )
   endif()
 
@@ -175,8 +174,6 @@ function(add_mercury_test test_name)
       foreach(protocol ${NA_${upper_comm}_TESTING_PROTOCOL})
         add_mercury_test_comm(${test_name} ${comm} ${protocol} "")
       endforeach()
-    else()
-      add_mercury_test_comm(${test_name} ${comm} "" "")
     endif()
   endforeach()
 endfunction()

--- a/Testing/na/CMakeLists.txt
+++ b/Testing/na/CMakeLists.txt
@@ -34,22 +34,21 @@ macro(add_na_test_comm test_name server client comm protocol)
     set(test_args ${test_args} --protocol ${protocol})
   endif()
 
-  # Dynamic client/server test
-  add_test(NAME "na_${full_test_name}"
-    COMMAND $<TARGET_FILE:mercury_test_driver>
-    --server $<TARGET_FILE:na_test_${server}>
-    --client $<TARGET_FILE:na_test_${client}> ${test_args}
-  )
-
   # Static client/server test
-  if(${comm} STREQUAL "mpi")
-    set(static_test_name ${full_test_name}_static)
+  if(${comm} STREQUAL "mpi" AND ${protocol} STREQUAL "static")
     set(static_test_args ${test_args} --static)
-    add_test(NAME "na_${static_test_name}"
+    add_test(NAME "na_${full_test_name}"
       COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1
       ${MPIEXEC_PREFLAGS} $<TARGET_FILE:na_test_${server}> ${MPIEXEC_POSTFLAGS}
       ${static_test_args} : ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
       ${MPIEXEC_PREFLAGS} $<TARGET_FILE:na_test_${client}> ${static_test_args}
+    )
+  else()
+    # Dynamic client/server test
+    add_test(NAME "na_${full_test_name}"
+      COMMAND $<TARGET_FILE:mercury_test_driver>
+      --server $<TARGET_FILE:na_test_${server}>
+      --client $<TARGET_FILE:na_test_${client}> ${test_args}
     )
   endif()
 endmacro()

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -587,8 +587,10 @@ na_bmi_initialize(na_class_t * na_class, const struct na_info *na_info,
         na_bool_t listen)
 {
     char *method_list = NULL;
+    char *listen_addr = NULL;
     int flag;
     size_t method_list_len;
+    size_t listen_addr_len;
     na_return_t ret = NA_SUCCESS;
 
     flag = (listen) ? BMI_INIT_SERVER : 0;
@@ -606,11 +608,25 @@ na_bmi_initialize(na_class_t * na_class, const struct na_info *na_info,
     strcpy(method_list, "bmi_");
     strcat(method_list, na_info->protocol_name);
 
+    if (listen && na_info->host_name) {
+        listen_addr_len = strlen(na_info->protocol_name) + strlen("://localhost:") +
+            strlen(na_info->host_name);
+        listen_addr = (char *) malloc(listen_addr_len+1);
+        if (!listen_addr) {
+            NA_LOG_ERROR("Could not allocate listen_addr");
+            ret = NA_NOMEM_ERROR;
+            goto done;
+        }
+        sprintf(listen_addr, "%s://localhost:%s", na_info->protocol_name,
+                na_info->host_name);
+    }
+
     ret = na_bmi_init(na_class, (listen) ? method_list : NULL,
-            (listen) ? na_info->port_name : NULL, flag);
+            (listen) ? listen_addr : NULL, flag);
 
 done:
     free(method_list);
+    free(listen_addr);
     return ret;
 }
 

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -1105,6 +1105,18 @@ na_mpi_initialize(na_class_t *na_class, const struct na_info *na_info,
     /* Check flags */
     if (strcmp(na_info->protocol_name, "static") == 0)
         flags |= MPI_INIT_STATIC;
+    else if (strcmp(na_info->protocol_name, "dynamic") != 0) {
+        NA_LOG_ERROR("Unknown protocol name for MPI, "
+                "expected \"dynamic\" or \"static\". Falling back to dynamic");
+        goto done;
+    }
+
+    /* ensure user didn't pass in a host string (it's ignored) */
+    if (na_info->host_name != NULL) {
+        NA_LOG_ERROR("Host name is unused when initializing MPI");
+        goto done;
+    }
+
     listening = (na_bool_t) (flags & MPI_INIT_SERVER);
     NA_MPI_PRIVATE_DATA(na_class)->listening = listening;
 

--- a/src/na/na_private.h
+++ b/src/na/na_private.h
@@ -21,9 +21,7 @@
 struct na_info {
     char *class_name;    /* Class name (e.g., bmi) */
     char *protocol_name; /* Protocol (e.g., tcp, ib) */
-    char *host_name;     /* Host */
-    int   port;          /* Port for communication */
-    char *port_name;     /* Identifies the server and can be used by a client */
+    char *host_name;     /* Host (may be NULL in anonymous mode) */
 };
 
 /* Private callback type for NA plugins */


### PR DESCRIPTION
Here's an initial look to get an idea of what my address parsing changes would do. Strategy is to parse through the class+protocol pair, then leave the remainder for the NA layer. MPI and CCI already ignore the host name, so there was not much to do there. BMI requires reconstructing the "protocol://hostname:port", but that's a fairly simple piece of code.

Note that addr_lookup in the top-level NA layer just peeks at the class name, and passes the remainder down to the plugin. The BMI and CCI plugins then pass them directly to the libs, while MPI parses the port string starting from ';', effectively ignoring the "protocol://" portion.

TODO:

- [x] Modify tests to init clients in anon mode ("class+protocol"). Currently passes in the *server* string to initialize.
- [x] ~~Modify tests to always get the server address through file. Right now it does sometimes but not others. Will be simpler to just have one code path, then we can test things like having anon-mode servers.~~ This actually isn't the case, I misread the code.
- [x] Get rid of hard-coded tcp default protocol in tests (or just special case MPI to "dynamic") - use the NA_*_TESTING_PROTOCOL variables for this instead.
- [x] Get rid of default protocol check in test code, enforce given protocol
- [x] Turn MPI error checks (bad protocol, existence of hostname during initialization) into errors once tests are changed. They are currently warnings.
- [x] Rebase on Phil's cci_create_endpoint_at branch once it gets merged, and incorporate call into code.
- [x] Special-case address creation in test code. BMI, CCI+tcp(+verbs?) - hostname:port. CCI+sm - pid:tag (need to check format). MPI: nothing. Right now, hardcodes host string to hostname:port unless using MPI.
- [x] ~~Similarly, modify BMI to allow anon-mode servers? This might require a BMI change, if so, then just error out when no hoststring is provided at the NA layer.~~ Not worth the trouble.

Might have forgot one or two...