### PR TITLE
reduced memory allocation

### DIFF
--- a/Testing/na/test_cancel_client.c
+++ b/Testing/na/test_cancel_client.c
@@ -98,7 +98,7 @@ msg_unexpected_send_cb(const struct na_cb_info *callback_info)
         sprintf(params->send_buf, "Hello again Server!");
         ret = NA_Msg_send_unexpected(params->na_class, params->context,
             NULL, NULL, params->send_buf, params->send_buf_len, params->server_addr,
-            NA_TEST_SEND_TAG, NA_OP_ID_IGNORE);
+            NA_TEST_SEND_TAG, NULL, NA_OP_ID_IGNORE);
         if (ret != NA_SUCCESS) {
             fprintf(stderr, "Could not start send of unexpected message\n");
         }
@@ -177,7 +177,7 @@ msg_expected_send_cb(const struct na_cb_info *callback_info)
         printf("Sending again local memory handle...\n");
         ret = NA_Msg_send_expected(params->na_class, params->context,
             NULL, NULL, params->send_buf, params->send_buf_len, params->server_addr,
-            NA_TEST_BULK_TAG, NA_OP_ID_IGNORE);
+            NA_TEST_BULK_TAG, NULL, NA_OP_ID_IGNORE);
         if (ret != NA_SUCCESS) {
             fprintf(stderr, "Could not start send of memory handle\n");
             return ret;
@@ -208,7 +208,7 @@ test_send(struct na_test_params *params)
     /* Preposting response */
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
         msg_expected_recv_cb, params, params->recv_buf, params->recv_buf_len,
-        params->server_addr, send_tag + 1, &op_id);
+        params->server_addr, send_tag + 1, NULL, &op_id);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not prepost recv of expected message\n");
         return EXIT_FAILURE;
@@ -223,7 +223,7 @@ test_send(struct na_test_params *params)
 
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
         msg_expected_recv_cb, params, params->recv_buf, params->recv_buf_len,
-        params->server_addr, send_tag + 1, NA_OP_ID_IGNORE);
+        params->server_addr, send_tag + 1, NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not prepost recv of expected message\n");
         return EXIT_FAILURE;
@@ -232,7 +232,7 @@ test_send(struct na_test_params *params)
     /* Try to cancel unexpected send */
     na_ret = NA_Msg_send_unexpected(params->na_class, params->context,
         msg_unexpected_send_cb, params, params->send_buf, params->send_buf_len,
-        params->server_addr, send_tag, &op_id);
+        params->server_addr, send_tag, NULL, &op_id);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of unexpected message\n");
         return EXIT_FAILURE;
@@ -284,7 +284,7 @@ test_bulk(struct na_test_params *params)
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
         ack_expected_recv_cb, params, params->recv_buf, params->recv_buf_len,
         params->server_addr, ack_tag,
-        NA_OP_ID_IGNORE);
+        NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start receive of acknowledgment\n");
         return EXIT_FAILURE;
@@ -294,7 +294,7 @@ test_bulk(struct na_test_params *params)
     printf("Sending local memory handle...\n");
     na_ret = NA_Msg_send_expected(params->na_class, params->context,
         msg_expected_send_cb, params, params->send_buf, params->send_buf_len,
-        params->server_addr, bulk_tag, &op_id);
+        params->server_addr, bulk_tag, NULL, &op_id);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of memory handle\n");
         return EXIT_FAILURE;

--- a/Testing/na/test_cancel_server.c
+++ b/Testing/na/test_cancel_server.c
@@ -51,7 +51,7 @@ msg_unexpected_recv_cb(const struct na_cb_info *callback_info)
         printf("NA_Msg_recv_unexpected() was successfully canceled\n");
         ret = NA_Msg_recv_unexpected(params->na_class, params->context,
             msg_unexpected_recv_cb, params, params->recv_buf,
-            params->recv_buf_len, NA_OP_ID_IGNORE);
+            params->recv_buf_len, NULL, NA_OP_ID_IGNORE);
         if (ret != NA_SUCCESS) {
             fprintf(stderr, "Could not post recv of unexpected message\n");
         }
@@ -123,7 +123,7 @@ bulk_put_cb(const struct na_cb_info *callback_info)
     printf("Sending end of transfer ack...\n");
     ret = NA_Msg_send_expected(params->na_class, params->context,
         msg_expected_send_final_cb, NULL, params->send_buf,
-        params->send_buf_len, params->source_addr, ack_tag,
+        params->send_buf_len, params->source_addr, ack_tag, NULL,
         NA_OP_ID_IGNORE);
     if (ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of acknowledgment\n");
@@ -263,7 +263,7 @@ test_send_respond(struct na_test_params *params, na_tag_t send_tag)
 
     na_ret = NA_Msg_send_expected(params->na_class, params->context,
         NULL, NULL, params->send_buf, params->send_buf_len, params->source_addr,
-        send_tag, NA_OP_ID_IGNORE);
+        send_tag, NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of message\n");
         return EXIT_FAILURE;
@@ -298,7 +298,8 @@ test_bulk_prepare(struct na_test_params *params)
     printf("Receiving remote memory handle...\n");
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
         mem_handle_expected_recv_cb, params, params->recv_buf,
-        params->recv_buf_len, params->source_addr, bulk_tag, NA_OP_ID_IGNORE);
+        params->recv_buf_len, params->source_addr, bulk_tag, NULL,
+        NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start recv of memory handle\n");
         return EXIT_FAILURE;
@@ -343,7 +344,7 @@ main(int argc, char *argv[])
         /* Recv a message from a client */
         na_ret = NA_Msg_recv_unexpected(params.na_class, params.context,
             msg_unexpected_recv_cb, &params, params.recv_buf,
-            params.recv_buf_len, &op_id);
+            params.recv_buf_len, NULL, &op_id);
         if (na_ret != NA_SUCCESS) {
             fprintf(stderr, "Could not post recv of unexpected message\n");
             return EXIT_FAILURE;

--- a/Testing/na/test_client.c
+++ b/Testing/na/test_client.c
@@ -131,7 +131,7 @@ test_send(struct na_test_params *params, na_tag_t send_tag)
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
             &msg_expected_recv_cb, params, params->recv_buf,
             params->recv_buf_len, params->server_addr, send_tag + 1,
-            NA_OP_ID_IGNORE);
+            NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not prepost recv of expected message\n");
         return EXIT_FAILURE;
@@ -139,7 +139,7 @@ test_send(struct na_test_params *params, na_tag_t send_tag)
 
     na_ret = NA_Msg_send_unexpected(params->na_class, params->context,
             NULL, NULL, params->send_buf, params->send_buf_len,
-            params->server_addr, send_tag, NA_OP_ID_IGNORE);
+            params->server_addr, send_tag, NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of unexpected message\n");
         return EXIT_FAILURE;
@@ -184,7 +184,7 @@ test_bulk(struct na_test_params *params)
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
             &ack_expected_recv_cb, params, params->recv_buf,
             params->recv_buf_len, params->server_addr, ack_tag,
-            NA_OP_ID_IGNORE);
+            NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start receive of acknowledgment\n");
         return EXIT_FAILURE;
@@ -194,7 +194,7 @@ test_bulk(struct na_test_params *params)
     printf("Sending local memory handle...\n");
     na_ret = NA_Msg_send_expected(params->na_class, params->context,
             NULL, NULL, params->send_buf, params->send_buf_len,
-            params->server_addr, bulk_tag, NA_OP_ID_IGNORE);
+            params->server_addr, bulk_tag, NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of memory handle\n");
         return EXIT_FAILURE;

--- a/Testing/na/test_server.c
+++ b/Testing/na/test_server.c
@@ -90,7 +90,8 @@ bulk_put_cb(const struct na_cb_info *callback_info)
     printf("Sending end of transfer ack...\n");
     ret = NA_Msg_send_expected(params->na_class, params->context,
         msg_expected_send_final_cb, NULL, params->send_buf,
-        params->send_buf_len, params->source_addr, ack_tag, NA_OP_ID_IGNORE);
+        params->send_buf_len, params->source_addr, ack_tag, NULL,
+        NA_OP_ID_IGNORE);
     if (ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of acknowledgment\n");
         return ret;
@@ -202,7 +203,7 @@ test_send_respond(struct na_test_params *params, na_tag_t send_tag)
 
     na_ret = NA_Msg_send_expected(params->na_class, params->context,
         NULL, NULL, params->send_buf, params->send_buf_len, params->source_addr,
-        send_tag, NA_OP_ID_IGNORE);
+        send_tag, NULL, NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start send of message\n");
         return EXIT_FAILURE;
@@ -237,7 +238,8 @@ test_bulk_prepare(struct na_test_params *params)
     printf("Receiving remote memory handle...\n");
     na_ret = NA_Msg_recv_expected(params->na_class, params->context,
         mem_handle_expected_recv_cb, params, params->recv_buf,
-        params->recv_buf_len, params->source_addr, bulk_tag, NA_OP_ID_IGNORE);
+        params->recv_buf_len, params->source_addr, bulk_tag, NULL,
+        NA_OP_ID_IGNORE);
     if (na_ret != NA_SUCCESS) {
         fprintf(stderr, "Could not start recv of memory handle\n");
         return EXIT_FAILURE;
@@ -281,7 +283,7 @@ main(int argc, char *argv[])
         /* Recv a message from a client */
         na_ret = NA_Msg_recv_unexpected(params.na_class, params.context,
             msg_unexpected_recv_cb, &params, params.recv_buf,
-            params.recv_buf_len, NA_OP_ID_IGNORE);
+            params.recv_buf_len, NULL, NA_OP_ID_IGNORE);
 
         while (!test_done_g) {
             na_return_t trigger_ret;

--- a/src/mercury_bulk.c
+++ b/src/mercury_bulk.c
@@ -38,6 +38,7 @@
 struct hg_bulk_op_id {
     struct hg_class *hg_class;            /* HG class */
     hg_context_t *context;                /* Context */
+    struct hg_completion_entry compent;   /* Completion queue */
     hg_cb_t callback;                     /* Callback */
     void *arg;                            /* Callback arguments */
     hg_atomic_int32_t completed;          /* Operation completed TODO needed ? */
@@ -751,12 +752,7 @@ hg_bulk_complete(struct hg_bulk_op_id *hg_bulk_op_id)
     /* Mark operation as completed */
     hg_atomic_incr32(&hg_bulk_op_id->completed);
 
-    hg_completion_entry = (struct hg_completion_entry *) malloc(sizeof(struct hg_completion_entry));
-    if (!hg_completion_entry) {
-        HG_LOG_ERROR("Could not allocate HG completion entry");
-        ret = HG_NOMEM_ERROR;
-        goto done;
-    }
+    hg_completion_entry = &hg_bulk_op_id->compent;
     hg_completion_entry->op_type = HG_BULK;
     hg_completion_entry->op_id.hg_bulk_op_id = hg_bulk_op_id;
 
@@ -767,8 +763,6 @@ hg_bulk_complete(struct hg_bulk_op_id *hg_bulk_op_id)
     }
 
 done:
-    if (ret != HG_SUCCESS)
-        free(hg_completion_entry);
     return ret;
 }
 

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1701,7 +1701,7 @@ hg_core_self_cb(const struct hg_cb_info *callback_info)
     /* Assign forward callback back to handle */
     hg_handle->callback = hg_self_cb_info->forward_cb;
     hg_handle->arg = hg_self_cb_info->forward_arg;
-    hg_handle->cb_type = HG_CB_FORWARD;
+    hg_handle->cb_type = HG_CB_INTFORWARD;
 
     /* Increment refcount and push handle back to completion queue */
     hg_atomic_incr32(&hg_handle->ref_count);

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -377,7 +377,9 @@ HG_Core_get_output(
  *
  * \param handle [IN]           HG handle
  * \param callback [IN]         pointer to function callback
- * \param arg [IN]              pointer to data passed to callback
+ * \param usercb [IN]           user-level callback
+ * \param userarg [IN]          arg for usercb
+ * \param extra_in_buf [IN]     extra input buffer
  * \param extra_in_handle [IN]  bulk handle to extra input buffer
  * \param size_to_send [IN]     size of request to transmit
  *
@@ -387,7 +389,9 @@ HG_EXPORT hg_return_t
 HG_Core_forward(
         hg_handle_t handle,
         hg_cb_t callback,
-        void *arg,
+        hg_cb_t usercb,
+        void *userarg,
+        void *extra_in_buf,
         hg_bulk_t extra_in_handle,
         hg_size_t size_to_send
         );

--- a/src/mercury_private.h
+++ b/src/mercury_private.h
@@ -42,6 +42,7 @@ typedef enum {
 /* Completion queue entry */
 struct hg_completion_entry {
     hg_op_type_t op_type;
+    TAILQ_ENTRY(hg_completion_entry) q;
     union {
         struct hg_op_id *hg_op_id;
         struct hg_handle *hg_handle;

--- a/src/mercury_types.h
+++ b/src/mercury_types.h
@@ -12,6 +12,13 @@
 #define MERCURY_TYPES_H
 
 #include "mercury_config.h"
+#include "mercury_util_config.h"
+
+#ifdef HG_UTIL_HAS_SYS_QUEUE_H
+#include <sys/queue.h>
+#else
+#include "mercury_sys_queue.h"
+#endif
 
 /*************************************/
 /* Public Type and Struct Definition */

--- a/src/mercury_types.h
+++ b/src/mercury_types.h
@@ -91,8 +91,13 @@ typedef enum hg_cb_type {
     HG_CB_LOOKUP,       /*!< lookup callback */
     HG_CB_FORWARD,      /*!< forward callback */
     HG_CB_RESPOND,      /*!< respond callback */
-    HG_CB_BULK          /*!< bulk transfer callback */
+    HG_CB_BULK,         /*!< bulk transfer callback */
+    HG_CB_INTFORWARD    /*!< internal forward callback */
 } hg_cb_type_t;
+
+/* HG callback */
+struct hg_cb_info;      /* defined below */
+typedef hg_return_t (*hg_cb_t)(const struct hg_cb_info *callback_info);
 
 /* Callback info structs */
 struct hg_cb_info_lookup {
@@ -101,6 +106,14 @@ struct hg_cb_info_lookup {
 
 struct hg_cb_info_forward {
     hg_handle_t handle; /* HG handle */
+};
+
+struct hg_cb_info_intforward {
+    hg_handle_t handle;        /* HG handle */
+    hg_cb_t usercb;            /* user-level callback */
+    void *userarg;             /* user arg */
+    hg_bulk_t extra_in_handle; /* extra buf handle if handle isn't big enough */
+    void *extra_in_buf;        /* extra buf itself */
 };
 
 struct hg_cb_info_respond {
@@ -122,12 +135,12 @@ struct hg_cb_info {
         struct hg_cb_info_forward forward;
         struct hg_cb_info_respond respond;
         struct hg_cb_info_bulk bulk;
+        struct hg_cb_info_intforward intforward;
     } info;
 };
 
-/* RPC / HG callbacks */
+/* RPC callback */
 typedef hg_return_t (*hg_rpc_cb_t)(hg_handle_t handle);
-typedef hg_return_t (*hg_cb_t)(const struct hg_cb_info *callback_info);
 
 /* Proc callback for serializing/deserializing parameters */
 typedef hg_return_t (*hg_proc_cb_t)(hg_proc_t proc, void *data);

--- a/src/na/na.h
+++ b/src/na/na.h
@@ -354,6 +354,42 @@ NA_Msg_get_max_tag(
         ) NA_WARN_UNUSED_RESULT;
 
 /**
+ * preallocate an op_id_t for the higher level code to save and pass back
+ * to us to use when it is needed (rather than have the low-level code
+ * malloc op_id_t's all the time).   this is optional.  if the lower-level
+ * NA doesn't support preallocation we just put null in the op_id and
+ * return success.  if we do preallocate an op_id, then we hold a reference
+ * to it which later must be released with NA_Prealloc_op_id_free().
+ *
+ * \param na_class [IN]   pointer to NA class
+ * \param context [IN]    pointer to context of execution
+ * \param op_id [OUT]     filled with pointer to preallocated op_id_t
+ *
+ * \return NA_SUCCESS or corresponding NA error code
+ */
+NA_EXPORT na_return_t
+NA_Prealloc_op_id(na_class_t *na_class,
+        na_context_t *context,
+        na_op_id_t *op_id
+                  );          
+
+/**
+ * free preallocated op_id_t.   high level code calls this when it
+ * is done with a preallocated op_id.
+ *
+ * \param na_class [IN]   pointer to NA class
+ * \param context [IN]    pointer to context of execution
+ * \param op_id [IN]      pointer to preallocated op_id_t
+ *
+ * \return NA_SUCCESS or corresponding NA error code
+ */
+NA_EXPORT na_return_t
+NA_Prealloc_op_id_free(na_class_t *na_class,
+        na_context_t *context,
+        na_op_id_t op_id
+                  );          
+
+/**
  * Send an unexpected message to dest.
  * Unexpected sends do not require a matching receive to complete. After
  * completion, user callback is placed into a completion queue and can be
@@ -370,6 +406,7 @@ NA_Msg_get_max_tag(
  * \param buf_size [IN]         buffer size
  * \param dest [IN]             abstract address of destination
  * \param tag [IN]              tag attached to message
+ * \param op_id_in [IN]         optional preallocated op_id we can use
  * \param op_id [OUT]           pointer to returned operation ID
  *
  * \return NA_SUCCESS or corresponding NA error code
@@ -384,6 +421,7 @@ NA_Msg_send_unexpected(
         na_size_t     buf_size,
         na_addr_t     dest,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -399,6 +437,7 @@ NA_Msg_send_unexpected(
  * \param arg [IN]              pointer to data passed to callback
  * \param buf [IN]              pointer to send buffer
  * \param buf_size [IN]         buffer size
+ * \param op_id_in [IN]         optional preallocated op_id we can use
  * \param op_id [OUT]           pointer to returned operation ID
  *
  * \return NA_SUCCESS or corresponding NA error code
@@ -411,6 +450,7 @@ NA_Msg_recv_unexpected(
         void         *arg,
         void         *buf,
         na_size_t     buf_size,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -430,6 +470,7 @@ NA_Msg_recv_unexpected(
  * \param buf_size [IN]         buffer size
  * \param dest [IN]             abstract address of destination
  * \param tag [IN]              tag attached to message
+ * \param op_id_in [IN]         optional preallocated op_id we can use
  * \param op_id [OUT]           pointer to returned operation ID
  *
  * \return NA_SUCCESS or corresponding NA error code
@@ -444,6 +485,7 @@ NA_Msg_send_expected(
         na_size_t     buf_size,
         na_addr_t     dest,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -459,6 +501,7 @@ NA_Msg_send_expected(
  * \param buf_size [IN]         buffer size
  * \param source [IN]           abstract address of source
  * \param tag [IN]              matching tag used to receive message
+ * \param op_id_in [IN]         optional preallocated op_id we can use
  * \param op_id [OUT]           pointer to returned operation ID
  *
  * \return NA_SUCCESS or corresponding NA error code
@@ -473,6 +516,7 @@ NA_Msg_recv_expected(
         na_size_t     buf_size,
         na_addr_t     source,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -124,6 +124,7 @@ struct na_bmi_op_id {
     na_cb_t callback; /* Callback */
     void *arg;
     na_bool_t completed; /* Operation completed */
+    struct na_cb_completion_data comp_data;
     union {
       struct na_bmi_info_lookup lookup;
       struct na_bmi_info_send_unexpected send_unexpected;
@@ -270,6 +271,7 @@ na_bmi_msg_send_unexpected(
         na_size_t     buf_size,
         na_addr_t     dest,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -282,6 +284,7 @@ na_bmi_msg_recv_unexpected(
         void         *arg,
         void         *buf,
         na_size_t     buf_size,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -296,6 +299,7 @@ na_bmi_msg_send_expected(
         na_size_t     buf_size,
         na_addr_t     dest,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -310,6 +314,7 @@ na_bmi_msg_recv_expected(
         na_size_t     buf_size,
         na_addr_t     source,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -491,6 +496,8 @@ const na_class_t na_bmi_class_g = {
         na_bmi_msg_get_max_expected_size,     /* msg_get_max_expected_size */
         na_bmi_msg_get_max_unexpected_size,   /* msg_get_max_expected_size */
         na_bmi_msg_get_max_tag,               /* msg_get_max_tag */
+        NULL,                                 /* prealloc_op_id */
+        NULL,                                 /* prealloc_op_id_free */
         na_bmi_msg_send_unexpected,           /* msg_send_unexpected */
         na_bmi_msg_recv_unexpected,           /* msg_recv_unexpected */
         na_bmi_msg_send_expected,             /* msg_send_expected */
@@ -985,7 +992,8 @@ na_bmi_msg_get_max_tag(na_class_t NA_UNUSED *na_class)
 static na_return_t
 na_bmi_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
         na_context_t *context, na_cb_t callback, void *arg, const void *buf,
-        na_size_t buf_size, na_addr_t dest, na_tag_t tag, na_op_id_t *op_id)
+        na_size_t buf_size, na_addr_t dest, na_tag_t tag,
+        NA_UNUSED na_op_id_t op_id_in, na_op_id_t *op_id)
 {
     bmi_context_id *bmi_context = (bmi_context_id *) context->plugin_context;
     bmi_size_t bmi_buf_size = (bmi_size_t) buf_size;
@@ -1044,7 +1052,7 @@ done:
 static na_return_t
 na_bmi_msg_recv_unexpected(na_class_t *na_class, na_context_t *context,
         na_cb_t callback, void *arg, void *buf, na_size_t buf_size,
-        na_op_id_t *op_id)
+        NA_UNUSED na_op_id_t op_id_in, na_op_id_t *op_id)
 {
     struct BMI_unexpected_info *unexpected_info = NULL;
     struct na_bmi_op_id *na_bmi_op_id = NULL;
@@ -1208,7 +1216,8 @@ na_bmi_msg_unexpected_op_pop(na_class_t *na_class)
 static na_return_t
 na_bmi_msg_send_expected(na_class_t NA_UNUSED *na_class, na_context_t *context,
         na_cb_t callback, void *arg, const void *buf, na_size_t buf_size,
-        na_addr_t dest, na_tag_t tag, na_op_id_t *op_id)
+        na_addr_t dest, na_tag_t tag, NA_UNUSED na_op_id_t op_id_in,
+        na_op_id_t *op_id)
 {
     bmi_context_id *bmi_context = (bmi_context_id *) context->plugin_context;
     bmi_size_t bmi_buf_size = (bmi_size_t) buf_size;
@@ -1266,7 +1275,8 @@ done:
 static na_return_t
 na_bmi_msg_recv_expected(na_class_t NA_UNUSED *na_class, na_context_t *context,
         na_cb_t callback, void *arg, void *buf, na_size_t buf_size,
-        na_addr_t source, na_tag_t tag, na_op_id_t *op_id)
+        na_addr_t source, na_tag_t tag, NA_UNUSED na_op_id_t op_id_in,
+        na_op_id_t *op_id)
 {
     bmi_context_id *bmi_context = (bmi_context_id *) context->plugin_context;
     bmi_size_t bmi_buf_size = (bmi_size_t) buf_size;
@@ -2116,13 +2126,8 @@ na_bmi_complete(struct na_bmi_op_id *na_bmi_op_id)
     /* Mark op id as completed */
     na_bmi_op_id->completed = NA_TRUE;
 
-    /* Allocate callback info */
-    callback_info = (struct na_cb_info *) malloc(sizeof(struct na_cb_info));
-    if (!callback_info) {
-        NA_LOG_ERROR("Could not allocate callback info");
-        ret = NA_NOMEM_ERROR;
-        goto done;
-    }
+    /* Init callback info */
+    callback_info = &na_bmi_op_id->comp_data.callback_info;
     callback_info->arg = na_bmi_op_id->arg;
     callback_info->ret = ((na_bmi_op_id->cancel & NA_BMI_CANCEL_R) ? NA_CANCELED : ret);
     callback_info->type = na_bmi_op_id->type;
@@ -2212,30 +2217,29 @@ na_bmi_complete(struct na_bmi_op_id *na_bmi_op_id)
             break;
     }
 
-    ret = na_cb_completion_add(na_bmi_op_id->context, na_bmi_op_id->callback,
-            callback_info, &na_bmi_release, na_bmi_op_id);
+    na_bmi_op_id->comp_data.callback = na_bmi_op_id->callback;
+    na_bmi_op_id->comp_data.plugin_callback = &na_bmi_release;
+    na_bmi_op_id->comp_data.plugin_callback_args = na_bmi_op_id;
+    
+    ret = na_cb_completion_add(na_bmi_op_id->context, &na_bmi_op_id->comp_data);
     if (ret != NA_SUCCESS) {
         NA_LOG_ERROR("Could not add callback to completion queue");
         goto done;
     }
 
 done:
-    if (ret != NA_SUCCESS) {
-        free(callback_info);
-    }
     return ret;
 }
 
 /*---------------------------------------------------------------------------*/
 static void
-na_bmi_release(struct na_cb_info *callback_info, void *arg)
+na_bmi_release(NA_UNUSED struct na_cb_info *callback_info, void *arg)
 {
     struct na_bmi_op_id *na_bmi_op_id = (struct na_bmi_op_id *) arg;
 
     if (na_bmi_op_id && !na_bmi_op_id->completed) {
         NA_LOG_ERROR("Releasing resources from an uncompleted operation");
     }
-    free(callback_info);
     free(na_bmi_op_id);
 }
 

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -1053,7 +1053,7 @@ na_bmi_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
     na_return_t ret = NA_SUCCESS;
     int bmi_ret;
 
-    /* Get or allocat op_id */
+    /* Use preallocated op_id if given, otherwise allocate one */
     na_bmi_op_id = op_id_in;
     if (na_bmi_op_id == NULL) {    
         na_bmi_op_id = (struct na_bmi_op_id *)
@@ -1114,7 +1114,7 @@ na_bmi_msg_recv_unexpected(na_class_t *na_class, na_context_t *context,
     struct na_bmi_op_id *na_bmi_op_id;
     na_return_t ret = NA_SUCCESS;
 
-    /* Get or allocat op_id */
+    /* Use preallocated op_id if given, otherwise allocate one */
     na_bmi_op_id = op_id_in;
     if (na_bmi_op_id == NULL) {    
         na_bmi_op_id = (struct na_bmi_op_id *)
@@ -1289,7 +1289,7 @@ na_bmi_msg_send_expected(na_class_t NA_UNUSED *na_class, na_context_t *context,
     na_return_t ret = NA_SUCCESS;
     int bmi_ret;
 
-    /* Get or allocate op_id */
+    /* Use preallocated op_id if given, otherwise allocate one */
     na_bmi_op_id = op_id_in;
     if (na_bmi_op_id == NULL) {    
         na_bmi_op_id = (struct na_bmi_op_id *)
@@ -1354,7 +1354,7 @@ na_bmi_msg_recv_expected(na_class_t NA_UNUSED *na_class, na_context_t *context,
     na_return_t ret = NA_SUCCESS;
     int bmi_ret;
 
-    /* Get or allocate op_id */
+    /* Use preallocated op_id if given, otherwise allocate one */
     na_bmi_op_id = op_id_in;
     if (na_bmi_op_id == NULL) {    
         na_bmi_op_id = (struct na_bmi_op_id *)

--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -244,6 +244,19 @@ na_cci_msg_get_max_unexpected_size(na_class_t * na_class);
 static na_tag_t
 na_cci_msg_get_max_tag(na_class_t * na_class);
 
+/* prealloc */
+static na_return_t
+na_cci_prealloc_op_id(
+    na_class_t *na_class,
+    na_context_t *context,
+    na_op_id_t *op_id);
+
+static na_return_t
+na_cci_prealloc_op_id_free(
+    na_class_t *na_class,
+    na_context_t *context,
+    na_op_id_t op_id);
+
 /* msg_send_unexpected */
 static na_return_t
 na_cci_msg_send_unexpected(na_class_t * na_class, na_context_t * context,
@@ -360,8 +373,8 @@ const na_class_t na_cci_class_g = {
     na_cci_msg_get_max_expected_size,       /* msg_get_max_expected_size */
     na_cci_msg_get_max_unexpected_size,     /* msg_get_max_expected_size */
     na_cci_msg_get_max_tag,                 /* msg_get_max_tag */
-    NULL,                                   /* prealloc_op_id */
-    NULL,                                   /* prealloc_op_id_free */
+    na_cci_prealloc_op_id,                  /* prealloc_op_id */
+    na_cci_prealloc_op_id_free,             /* prealloc_op_id_free */
     na_cci_msg_send_unexpected,             /* msg_send_unexpected */
     na_cci_msg_recv_unexpected,             /* msg_recv_unexpected */
     na_cci_msg_send_expected,               /* msg_send_expected */
@@ -671,7 +684,7 @@ na_cci_addr_lookup(na_class_t NA_UNUSED * na_class, na_context_t * context,
     na_return_t ret = NA_SUCCESS;
     int rc;
 
-    /* Allocate op_id */
+    /* Allocate op_id (XXX: calloc zeros too, needed?) */
     na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
     if (!na_cci_op_id) {
         NA_LOG_ERROR("Could not allocate NA CCI operation ID");
@@ -904,6 +917,37 @@ na_cci_msg_get_max_tag(na_class_t NA_UNUSED * na_class)
 
     return max_tag;
 }
+/*---------------------------------------------------------------------------*/
+static na_return_t
+na_cci_prealloc_op_id(na_class_t NA_UNUSED *na_class,
+    na_context_t NA_UNUSED *na_context, na_op_id_t *op_id)
+{
+    struct na_cci_op_id *precci_op_id;
+
+    /* optional: if malloc fails we still return success */
+    precci_op_id = (struct na_cci_op_id *) malloc(sizeof(struct na_cci_op_id));
+    if (precci_op_id) {
+        /* the preallocation holds a reference to prevent freeing */
+        hg_atomic_set32(&precci_op_id->refcnt, 1);
+    }
+
+    *op_id = precci_op_id;    /* will be null if malloc failed */
+    
+    return(NA_SUCCESS);    
+}
+                      
+/*---------------------------------------------------------------------------*/
+static na_return_t
+na_cci_prealloc_op_id_free(na_class_t NA_UNUSED *na_class,
+    na_context_t NA_UNUSED *na_context, na_op_id_t op_id)
+{
+    struct na_cci_op_id *na_cci_op_id = (struct na_cci_op_id *) op_id;
+
+    op_id_decref(na_cci_op_id);  /* should drop to 0 and free */
+
+    return(NA_SUCCESS);
+}
+
 
 /*---------------------------------------------------------------------------*/
 static na_return_t
@@ -926,18 +970,27 @@ na_cci_msg_send_unexpected(na_class_t *na_class, na_context_t * context,
 
     addr_addref(na_cci_addr); /* for na_cci_complete() */
 
-    /* Allocate op_id */
-    na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
-    if (!na_cci_op_id) {
-        NA_LOG_ERROR("Could not allocate NA CCI operation ID");
-        ret = NA_NOMEM_ERROR;
-        goto out;
+    /* Use preallocated op_id if given, otherwise allocate one */
+    na_cci_op_id = op_id_in;
+    if (na_cci_op_id) {
+        hg_atomic_incr32(&na_cci_op_id->refcnt);  /* should be 2 now */
+    } else {
+        /* XXX: calloc? */
+        na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
+        if (!na_cci_op_id) {
+            NA_LOG_ERROR("Could not allocate NA CCI operation ID");
+            ret = NA_NOMEM_ERROR;
+            goto out;
+        }
+        hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     }
+        
+    /* now na_cci_op_id is not null and has the correct ref count */
+    
     na_cci_op_id->context = context;
     na_cci_op_id->type = NA_CB_SEND_UNEXPECTED;
     na_cci_op_id->callback = callback;
     na_cci_op_id->arg = arg;
-    hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     hg_atomic_set32(&na_cci_op_id->completed, 0);
     hg_atomic_set32(&na_cci_op_id->canceled, 0);
     na_cci_op_id->info.send_unexpected.op_id = 0;
@@ -967,7 +1020,8 @@ na_cci_msg_send_unexpected(na_class_t *na_class, na_context_t * context,
 out:
     if (ret != NA_SUCCESS) {
         addr_decref(na_cci_addr);
-        free(na_cci_op_id);
+        if (na_cci_op_id)
+            op_id_decref(na_cci_op_id); /* frees if not preallocated */
     }
     return ret;
 }
@@ -982,18 +1036,27 @@ na_cci_msg_recv_unexpected(na_class_t * na_class, na_context_t * context,
     struct na_cci_info_recv_unexpected *rx = NULL;
     na_return_t ret = NA_SUCCESS;
 
-    /* Allocate na_op_id */
-    na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
-    if (!na_cci_op_id) {
-        NA_LOG_ERROR("Could not allocate NA CCI operation ID");
-        ret = NA_NOMEM_ERROR;
-        goto out;
+    /* Use preallocated op_id if given, otherwise allocate one */
+    na_cci_op_id = op_id_in;
+    if (na_cci_op_id) {
+        hg_atomic_incr32(&na_cci_op_id->refcnt);  /* should be 2 now */
+    } else {
+        /* XXX: calloc? */
+        na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
+        if (!na_cci_op_id) {
+            NA_LOG_ERROR("Could not allocate NA CCI operation ID");
+            ret = NA_NOMEM_ERROR;
+            goto out;
+        }
+        hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     }
+        
+    /* now na_cci_op_id is not null and has the correct ref count */
+    
     na_cci_op_id->context = context;
     na_cci_op_id->type = NA_CB_RECV_UNEXPECTED;
     na_cci_op_id->callback = callback;
     na_cci_op_id->arg = arg;
-    hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     hg_atomic_set32(&na_cci_op_id->completed, 0);
     hg_atomic_set32(&na_cci_op_id->canceled, 0);
     na_cci_op_id->info.recv_unexpected.buf = buf;
@@ -1036,7 +1099,8 @@ na_cci_msg_recv_unexpected(na_class_t * na_class, na_context_t * context,
 
 out:
     if (ret != NA_SUCCESS) {
-        free(na_cci_op_id);
+        if (na_cci_op_id)
+            op_id_decref(na_cci_op_id);  /* frees if not preallocated */
     }
     return ret;
 }
@@ -1158,18 +1222,27 @@ na_cci_msg_send_expected(na_class_t *na_class, na_context_t * context,
 
     addr_addref(na_cci_addr); /* for na_cci_complete() */
 
-    /* Allocate op_id */
-    na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
-    if (!na_cci_op_id) {
-        NA_LOG_ERROR("Could not allocate NA CCI operation ID");
-        ret = NA_NOMEM_ERROR;
-        goto out;
+    /* Use preallocated op_id if given, otherwise allocate one */
+    na_cci_op_id = op_id_in;
+    if (na_cci_op_id) {
+        hg_atomic_incr32(&na_cci_op_id->refcnt);  /* should be 2 now */
+    } else {
+        /* XXX: calloc? */
+        na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
+        if (!na_cci_op_id) {
+            NA_LOG_ERROR("Could not allocate NA CCI operation ID");
+            ret = NA_NOMEM_ERROR;
+            goto out;
+        }
+        hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     }
+        
+    /* now na_cci_op_id is not null and has the correct ref count */
+    
     na_cci_op_id->context = context;
     na_cci_op_id->type = NA_CB_SEND_EXPECTED;
     na_cci_op_id->callback = callback;
     na_cci_op_id->arg = arg;
-    hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     hg_atomic_set32(&na_cci_op_id->completed, 0);
     hg_atomic_set32(&na_cci_op_id->canceled, 0);
     na_cci_op_id->info.send_expected.op_id = 0;
@@ -1199,7 +1272,8 @@ na_cci_msg_send_expected(na_class_t *na_class, na_context_t * context,
 out:
     if (ret != NA_SUCCESS) {
         addr_decref(na_cci_addr);
-        free(na_cci_op_id);
+        if (na_cci_op_id)
+            op_id_decref(na_cci_op_id);  /* frees if not preallocated */
     }
     return ret;
 }
@@ -1226,18 +1300,27 @@ na_cci_msg_recv_expected(na_class_t NA_UNUSED * na_class,
 
     addr_addref(na_cci_addr); /* for na_cci_complete() */
 
-    /* Allocate na_op_id */
-    na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
-    if (!na_cci_op_id) {
-        NA_LOG_ERROR("Could not allocate NA CCI operation ID");
-        ret = NA_NOMEM_ERROR;
-        goto out;
+    /* Use preallocated op_id if given, otherwise allocate one */
+    na_cci_op_id = op_id_in;
+    if (na_cci_op_id) {
+        hg_atomic_incr32(&na_cci_op_id->refcnt);  /* should be 2 now */
+    } else {
+        /* XXX: calloc? */
+        na_cci_op_id = (na_cci_op_id_t *) calloc(1, sizeof(*na_cci_op_id));
+        if (!na_cci_op_id) {
+            NA_LOG_ERROR("Could not allocate NA CCI operation ID");
+            ret = NA_NOMEM_ERROR;
+            goto out;
+        }
+        hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     }
+        
+    /* now na_cci_op_id is not null and has the correct ref count */
+    
     na_cci_op_id->context = context;
     na_cci_op_id->type = NA_CB_RECV_EXPECTED;
     na_cci_op_id->callback = callback;
     na_cci_op_id->arg = arg;
-    hg_atomic_set32(&na_cci_op_id->refcnt, 1);
     hg_atomic_set32(&na_cci_op_id->completed, 0);
     hg_atomic_set32(&na_cci_op_id->canceled, 0);
     na_cci_op_id->info.recv_expected.na_cci_addr = na_cci_addr;
@@ -1278,7 +1361,8 @@ na_cci_msg_recv_expected(na_class_t NA_UNUSED * na_class,
 out:
     if (ret != NA_SUCCESS) {
         addr_decref(na_cci_addr);
-        free(na_cci_op_id);
+        if (na_cci_op_id)
+            op_id_decref(na_cci_op_id);  /* frees if not preallocated */
     }
     return ret;
 }
@@ -2022,7 +2106,7 @@ out:
 
 /*---------------------------------------------------------------------------*/
 static void
-na_cci_release(struct na_cb_info *callback_info, void *arg)
+na_cci_release(struct na_cb_info NA_UNUSED *callback_info, void *arg)
 {
     na_cci_op_id_t *na_cci_op_id = (na_cci_op_id_t *) arg;
 

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -148,6 +148,7 @@ struct na_mpi_op_id {
     void *arg;
     na_bool_t completed; /* Operation completed */
     na_bool_t canceled;  /* Operation canceled */
+    struct na_cb_completion_data comp_data;
     union {
       struct na_mpi_info_lookup lookup;
       struct na_mpi_info_send_unexpected send_unexpected;
@@ -354,6 +355,7 @@ na_mpi_msg_send_unexpected(
         na_size_t     buf_size,
         na_addr_t     dest,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -366,6 +368,7 @@ na_mpi_msg_recv_unexpected(
         void         *arg,
         void         *buf,
         na_size_t     buf_size,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -380,6 +383,7 @@ na_mpi_msg_send_expected(
         na_size_t     buf_size,
         na_addr_t     dest,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -394,6 +398,7 @@ na_mpi_msg_recv_expected(
         na_size_t     buf_size,
         na_addr_t     source,
         na_tag_t      tag,
+        na_op_id_t    op_id_in,
         na_op_id_t   *op_id
         );
 
@@ -564,6 +569,8 @@ const na_class_t na_mpi_class_g = {
         na_mpi_msg_get_max_expected_size,     /* msg_get_max_expected_size */
         na_mpi_msg_get_max_unexpected_size,   /* msg_get_max_expected_size */
         na_mpi_msg_get_max_tag,               /* msg_get_max_tag */
+        NULL,                                 /* prealloc_op_id */
+        NULL,                                 /* prealloc_op_id_free */
         na_mpi_msg_send_unexpected,           /* msg_send_unexpected */
         na_mpi_msg_recv_unexpected,           /* msg_recv_unexpected */
         na_mpi_msg_send_expected,             /* msg_send_expected */
@@ -1605,7 +1612,8 @@ na_mpi_msg_get_max_tag(na_class_t NA_UNUSED *na_class)
 static na_return_t
 na_mpi_msg_send_unexpected(na_class_t *na_class, na_context_t *context,
         na_cb_t callback, void *arg, const void *buf, na_size_t buf_size,
-        na_addr_t dest, na_tag_t tag, na_op_id_t *op_id)
+        na_addr_t dest, na_tag_t tag, NA_UNSED na_op_id_t op_id_in,
+        na_op_id_t *op_id)
 {
     int mpi_buf_size = (int) buf_size;
     int mpi_tag = (int) tag;
@@ -1655,7 +1663,7 @@ done:
 static na_return_t
 na_mpi_msg_recv_unexpected(na_class_t *na_class, na_context_t *context,
         na_cb_t callback, void *arg, void *buf, na_size_t buf_size,
-        na_op_id_t *op_id)
+        NA_UNUSED na_op_id_t op_id_in, na_op_id_t *op_id)
 {
     struct na_mpi_op_id *na_mpi_op_id = NULL;
     na_return_t ret = NA_SUCCESS;
@@ -1711,7 +1719,8 @@ done:
 static na_return_t
 na_mpi_msg_send_expected(na_class_t *na_class, na_context_t *context,
         na_cb_t callback, void *arg, const void *buf, na_size_t buf_size,
-        na_addr_t dest, na_tag_t tag, na_op_id_t *op_id)
+        na_addr_t dest, na_tag_t tag, NA_UNUSED na_op_id_t op_id_in,
+        na_op_id_t *op_id)
 {
     int mpi_buf_size = (int) buf_size;
     int mpi_tag = (int) tag;
@@ -1761,7 +1770,8 @@ done:
 static na_return_t
 na_mpi_msg_recv_expected(na_class_t *na_class, na_context_t *context,
         na_cb_t callback, void *arg, void *buf, na_size_t buf_size,
-        na_addr_t source, na_tag_t tag, na_op_id_t *op_id)
+        na_addr_t source, na_tag_t tag, NA_UNUSED na_op_id_t op_id_in,
+        na_op_id_t *op_id)
 {
     int mpi_buf_size = (int) buf_size;
     int mpi_tag = (int) tag;
@@ -2552,13 +2562,8 @@ na_mpi_complete(struct na_mpi_op_id *na_mpi_op_id)
     /* Mark op id as completed */
     na_mpi_op_id->completed = NA_TRUE;
 
-    /* Allocate callback info */
-    callback_info = (struct na_cb_info *) malloc(sizeof(struct na_cb_info));
-    if (!callback_info) {
-        NA_LOG_ERROR("Could not allocate callback info");
-        ret = NA_NOMEM_ERROR;
-        goto done;
-    }
+    /* Init callback info */
+    callback_info = &na_mpi_op_id->comp_data.callback_info;
     callback_info->arg = na_mpi_op_id->arg;
     callback_info->ret = (na_mpi_op_id->canceled) ? NA_CANCELED : ret;
     callback_info->type = na_mpi_op_id->type;
@@ -2657,30 +2662,29 @@ na_mpi_complete(struct na_mpi_op_id *na_mpi_op_id)
             break;
     }
 
-    ret = na_cb_completion_add(na_mpi_op_id->context, na_mpi_op_id->callback,
-            callback_info, &na_mpi_release, na_mpi_op_id);
+    na_mpi_op_id->comp_data.callback = na_mpi_op_id->callback;
+    na_mpi_op_id->comp_data.plugin_callback = &na_mpi_release;
+    na_mpi_op_id->comp_data.plugin_callback_args = na_bmi_op_id;
+    
+    ret = na_cb_completion_add(na_mpi_op_id->context, &na_mpi_op_id->comp_data);
     if (ret != NA_SUCCESS) {
         NA_LOG_ERROR("Could not add callback to completion queue");
         goto done;
     }
 
 done:
-    if (ret != NA_SUCCESS) {
-        free(callback_info);
-    }
     return ret;
 }
 
 /*---------------------------------------------------------------------------*/
 static void
-na_mpi_release(struct na_cb_info *callback_info, void *arg)
+na_mpi_release(NA_UNUSED struct na_cb_info *callback_info, void *arg)
 {
     struct na_mpi_op_id *na_mpi_op_id = (struct na_mpi_op_id *) arg;
 
     if (na_mpi_op_id && !na_mpi_op_id->completed) {
         NA_LOG_ERROR("Releasing resources from an uncompleted operation");
     }
-    free(callback_info);
     free(na_mpi_op_id);
 }
 

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -1612,7 +1612,7 @@ na_mpi_msg_get_max_tag(na_class_t NA_UNUSED *na_class)
 static na_return_t
 na_mpi_msg_send_unexpected(na_class_t *na_class, na_context_t *context,
         na_cb_t callback, void *arg, const void *buf, na_size_t buf_size,
-        na_addr_t dest, na_tag_t tag, NA_UNSED na_op_id_t op_id_in,
+        na_addr_t dest, na_tag_t tag, NA_UNUSED na_op_id_t op_id_in,
         na_op_id_t *op_id)
 {
     int mpi_buf_size = (int) buf_size;
@@ -2664,7 +2664,7 @@ na_mpi_complete(struct na_mpi_op_id *na_mpi_op_id)
 
     na_mpi_op_id->comp_data.callback = na_mpi_op_id->callback;
     na_mpi_op_id->comp_data.plugin_callback = &na_mpi_release;
-    na_mpi_op_id->comp_data.plugin_callback_args = na_bmi_op_id;
+    na_mpi_op_id->comp_data.plugin_callback_args = na_mpi_op_id;
     
     ret = na_cb_completion_add(na_mpi_op_id->context, &na_mpi_op_id->comp_data);
     if (ret != NA_SUCCESS) {


### PR DESCRIPTION
I looked at the mallocs in mercury in the critical path.  For one noop operation a 
mercury client does 14 memory allocations.  On the server it does 12 memory 
allocations per bake noop operation.

I looked at the mercury code and spent some time restructuring
it to reduce the number of memory allocations in the critical path,
assuming that the client will cache the hg_handle it uses to communiate
with the server.

Changes I made include:
       
      - removed mallocs associated with the hg_context pending
        and processing lists by converting them into a <sys/queue.h>
        LIST.

      - removed malloc associated with the hg_forward_cb_info
        structure and carry the info in the handle.  I had to
        add a new internal forwarding callback type to make this
        work with the current layering in the code.

      - removed memory allocation of hg_completion_entry by embedding it
        in other structures.  the completion queue becomes a simple TAILQ.

      - removed hg_queue allocate of na completion queue by converting
        it to a TAILQ

      - moved allocation of na_cb_completion_data and na_cb_info
        into the op_id data structures (so when you allocate an
        op_id, you get the na_cb_completion_data and na_cb_info
        with them)

     - add framework to allow higher level code to preallocate na send
       and recv op_id's at handle creation time.   use framework to
       allow high level code to pass preallocated NA op_id's down into
       the na layer at message send/recv time  (feature is optional)
       this involves two new NA calls: NA_Prealloc_op_id()
       and NA_Prealloc_op_id_free().

       currently applies only to expected/unexpected send/recv since
       that's that bake-bulk noop uses.   if you cache your hg_handles,
       the cache will include the preallocated NA structures.

     - added support for preallocated NA op_id's to BMI and CCI
       (not currently compiling MPI, so didn't do that one)


those changes combined with caching the hg_handle on the client
side reduce the number of critical path memory allocations for noop 
to zero.

[here's a detailed list of current mercury memory allocations on the
 critical path for a noop call]

     For the client side there are 14 memory allocations per noop:

(allocate handle)
  [1] malloc 184 bytes for hg_handle
    [2] posix_memalign 252 bytes (align=4096) for handle->in_buf
    [3] posix_memalign 252 bytes (align=4096) for handle->out_buf
(forward request)
  [4] malloc 32 bytes for hg_forward_cb_info   (HG_Forward)
    [5] calloc 128 bytes for a na_cci_op_id_t  (recv_expected: for reply)
    [6] calloc 128 bytes for a na_cci_op_id_t  (send_unexpect: for request)
(send completes)
    [7] malloc 40 bytes for na_cb_info struct
    [8] malloc 32 bytes for na_cb_completion
    [9] malloc 24 bytes for hg_queue_entry  (na_private_context->completion)
         /* trigger callback will discard, i think
            since na_completed_count == 1 */
(reply arrives)
    [10] malloc 40 bytes for na_cb_info struct
    [11] malloc 32 bytes for na_cb_completion
    [12] malloc 24 bytes for hg_queue_entry  (na_private_context->completion)
          /* trigger callback has na_completed_count == 2, can pass up */
(rpc now complete)
    [13] malloc 16 bytes for hg_completion_entry struct
    [14] malloc 24 bytes for hg_queue_entry struct
(the callback will now be triggered)

the server side has 12 memory allocations (i'm not counting any of
the init stuff that happens during server startup):

(server gets unexpected recv at NA layer and queues it at NA layer)
    [1] malloc 40 bytes for a na_cb_info struct
    [2] malloc 32 bytes for a na_cb_completion
    [3] malloc 24 bytes for a hg_queue_entry (for push)
(server HG callback triggered [hg_core_recv_input_cb()])
    [4] malloc 24 bytes for a hg_list_entry_t  (for "processing" list)
    [5] malloc 16 bytes for a hg_completion_entry
    [6] malloc 24 bytes for a hg_queue_entry   (put on HG completion queue)
(server collects req and runs noop)
(server sends reply with HG_Respond() on handle)
    [7] calloc 128 bytes for a na_cci_op_id_t    (sending reply)
(server's reply send completes)
    [8] malloc 40 bytes for na_cb_info struct
    [9] malloc 32 bytes for na_cb_completion
    [10] malloc 24 bytes for hg_queue_entry  (na_private_context->completion)
(rpc now complete-queue completion for server)
    [11] malloc 16 bytes for hg_completion_entry struct
    [12] malloc 24 bytes for hg_queue_entry struct

