### PR TITLE
remove unecessary poll() call in na_cci if remaining time is zero

### DIFF
--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -1896,10 +1896,13 @@ na_cci_progress(na_class_t * na_class, na_context_t * context,
         hg_time_get_current(&t1);
 
 #ifdef NA_CCI_HAS_POLL
-        pfd.fd = NA_CCI_PRIVATE_DATA(na_class)->fd;
-        pfd.events = POLLIN;
+        if(remaining > 0)
+        {
+            pfd.fd = NA_CCI_PRIVATE_DATA(na_class)->fd;
+            pfd.events = POLLIN;
 
-        poll(&pfd, 1, (int)(remaining * 1000.0));
+            poll(&pfd, 1, (int)(remaining * 1000.0));
+        }
 #endif
 
         rc = cci_get_event(e, &event);


### PR DESCRIPTION
Reduce latency by skipping the poll() system call if the na_cci progress loop has no timeout, or if timeout has been exhausted in previous iteration.