### PR TITLE
prevent segfault if HG_Init() fails

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1013,7 +1013,8 @@ hg_core_finalize(struct hg_class *hg_class)
     if (!hg_class) goto done;
 
     /* Delete function map */
-    hg_hash_table_free(hg_class->func_map);
+    if(hg_class->func_map)
+        hg_hash_table_free(hg_class->func_map);
     hg_class->func_map = NULL;
 
     /* Destroy context */


### PR DESCRIPTION
Minor bug fix: HG_Init() typically segfaults if you attempt to initialize with an unsupported transport.  This makes it difficult for callers to probe to see which ones are available.

HG_Init() also prints out verbose errors to stderr in this case, but that's probably for the best.