### PR TITLE
WIP: add mplex_id to hg_info and request header

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -885,6 +885,26 @@ HG_Registered(hg_class_t *hg_class, hg_id_t id, hg_bool_t *flag)
 
 /*---------------------------------------------------------------------------*/
 hg_return_t
+HG_Registered_name(hg_class_t *hg_class, const char *func_name, hg_id_t *id, hg_bool_t *flag)
+{
+    if (!hg_class) {
+        HG_LOG_ERROR("NULL HG class");
+        return HG_INVALID_PARAM;
+    }
+
+    if (!func_name) {
+        HG_LOG_ERROR("NULL string");
+        return HG_INVALID_PARAM;
+    }
+
+    /* Generate an ID from the function name */
+    *id = hg_hash_string(func_name);
+
+    return HG_Core_registered(hg_class, *id, flag);
+}
+
+/*---------------------------------------------------------------------------*/
+hg_return_t
 HG_Register_data(hg_class_t *hg_class, hg_id_t id, void *data,
     void (*free_callback)(void *))
 {

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -241,6 +241,25 @@ HG_Registered(
         );
 
 /**
+ * Indicate whether HG_Register() has been called for the RPC specified by
+ * func_name
+ *
+ * \param hg_class [IN]         pointer to HG class
+ * \param func_name [IN]        function name
+ * \param id [OUT]              function ID
+ * \param flag [OUT]            pointer to boolean
+ *
+ * \return HG_SUCCESS or corresponding HG error code
+ */
+HG_EXPORT hg_return_t
+HG_Registered_name(
+        hg_class_t *hg_class,
+        const char *func_name,
+        hg_id_t *id,
+        hg_bool_t *flag
+        );
+
+/**
  * Register and associate user data to registered function. When HG_Finalize()
  * is called, free_callback (if defined) is called to free the registered
  * data.

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1511,6 +1511,7 @@ hg_core_recv_input_cb(const struct na_cb_info *callback_info)
 
         /* Get operation ID from header */
         hg_handle->hg_info.id = hg_handle->in_header.id;
+        hg_handle->hg_info.mplex_id = hg_handle->in_header.mplex_id;
         hg_handle->cookie = hg_handle->in_header.cookie;
         hg_handle->no_response = (hg_handle->in_header.flags
             & HG_PROC_HEADER_NO_RESPONSE) ? HG_TRUE : HG_FALSE;
@@ -3210,6 +3211,7 @@ HG_Core_forward(hg_handle_t handle, hg_cb_t callback, void *arg,
     hg_handle->in_header.flags |= flags;
     flags = (hg_handle->no_response) ? HG_PROC_HEADER_NO_RESPONSE : 0x00;
     hg_handle->in_header.flags |= flags;
+    hg_handle->in_header.mplex_id = hg_handle->hg_info.mplex_id;
 
     /* Encode request header */
     ret = hg_proc_header_request(hg_handle->in_buf, hg_handle->in_buf_size,

--- a/src/mercury_proc_header.h
+++ b/src/mercury_proc_header.h
@@ -31,6 +31,7 @@ struct hg_header_request {
      hg_id_t     id;               /* RPC request identifier */
      hg_uint8_t  flags;            /* Flags (extra buffer) */
      hg_uint32_t cookie;           /* Random cookie */
+     hg_uint32_t mplex_id;         /* Multiplexing identifier */
      hg_uint16_t crc16;            /* CRC16 checksum */
      /* Should be 128 bits here */
      hg_bulk_t   extra_in_handle;  /* Extra handle (large data) */
@@ -63,7 +64,7 @@ struct hg_header_response {
  *
  * Request:
  * mercury byte / protocol version number / rpc id / flags (e.g. for extra buf) /
- * random cookie / crc16 / (bulk handle, there is space since payload is copied)
+ * random cookie / mplex_id / crc16 / (bulk handle, there is space since payload is copied)
  *
  * Response:
  * flags / error / cookie / crc16 / payload
@@ -77,7 +78,7 @@ struct hg_header_response {
 #define HG_IDENTIFIER (('H' << 1) | ('G')) /* 0xD7 */
 
 /* Mercury protocol version number */
-#define HG_PROTOCOL_VERSION 0x00000002
+#define HG_PROTOCOL_VERSION 0x00000003
 
 /* Encode/decode version number into uint32 */
 #define HG_GET_MAJOR(value) ((value >> 24) & 0xFF)

--- a/src/mercury_types.h
+++ b/src/mercury_types.h
@@ -34,6 +34,7 @@ struct hg_info {
     hg_context_t *context;      /* HG context */
     hg_addr_t addr;             /* HG address */
     hg_id_t id;                 /* RPC ID */
+    hg_uint32_t mplex_id;       /* Multiplexing identifier */
 };
 
 /**


### PR DESCRIPTION
- this field can be used by services atop Mercury to vector incoming
  RPCs to particular resources (e.g., cores) from the initial RPC handler