### PR TITLE
probe for available BMI port numbers

### DIFF
--- a/src/na/na.c
+++ b/src/na/na.c
@@ -1970,6 +1970,7 @@ NA_Error_to_string(na_return_t errnum)
     NA_ERROR_STRING_MACRO(NA_PERMISSION_ERROR, errnum, na_error_string);
     NA_ERROR_STRING_MACRO(NA_NOMEM_ERROR, errnum, na_error_string);
     NA_ERROR_STRING_MACRO(NA_PROTOCOL_ERROR, errnum, na_error_string);
+    NA_ERROR_STRING_MACRO(NA_ADDRINUSE_ERROR, errnum, na_error_string);
 
     return na_error_string;
 }

--- a/src/na/na.h
+++ b/src/na/na.h
@@ -46,7 +46,8 @@ typedef enum na_return {
     NA_PERMISSION_ERROR,    /*!< read/write permission error */
     NA_NOMEM_ERROR,         /*!< no memory error */
     NA_PROTOCOL_ERROR,      /*!< unknown error reported from the protocol layer */
-    NA_CANCELED             /*!< operation was canceled */
+    NA_CANCELED,            /*!< operation was canceled */
+    NA_ADDRINUSE_ERROR      /*!< address already in use */
 } na_return_t;
 
 /* Callback operation type */


### PR DESCRIPTION
Fixes #165 

Requires origin/master version of BMI as of 8/9/2017

- if no port number is specified for BMI in server mode, then try ports
  within a range until one of them works, and store default hostname and
  port as address that can be queried with HG_Addr_to_string() and used
  by other hosts