### PR TITLE
Checking for x86 before using cpu_spinwait

### DIFF
--- a/src/util/mercury_atomic_queue.h
+++ b/src/util/mercury_atomic_queue.h
@@ -69,7 +69,11 @@ struct hg_atomic_queue {
 #define HG_ATOMIC_QUEUE_ELT_SIZE sizeof(hg_atomic_int64_t)
 
 #ifndef cpu_spinwait
+#if defined(__x86_64__) || defined(__amd64__)
 #define cpu_spinwait() asm volatile("pause\n": : :"memory");
+#else
+#define cpu_spinwait();
+#endif
 #endif
 
 /*********************/


### PR DESCRIPTION
Check if its x86 before using cpu_spinwait, if not use
empty function now on other architectures.