### PR TITLE
na/ofi: fix a double free problem in error case

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -1348,6 +1348,7 @@ na_ofi_domain_close(struct na_ofi_domain *na_ofi_domain)
         if (na_ofi_domain->nod_prov->domain_attr->auth_key_size)
             na_ofi_domain->nod_prov->domain_attr->auth_key_size = 0;
         fi_freeinfo(na_ofi_domain->nod_prov);
+        na_ofi_domain->nod_prov = NULL;
     }
 
     if (na_ofi_domain->nod_addr_ht)
@@ -1492,8 +1493,10 @@ no_wait_obj:
     *na_ofi_endpoint_p = na_ofi_endpoint;
 
 out:
-    if (ret != NA_SUCCESS)
+    if (ret != NA_SUCCESS) {
         na_ofi_endpoint_close(na_ofi_endpoint);
+        *na_ofi_endpoint_p = NULL;
+    }
     return ret;
 }
 
@@ -1541,8 +1544,10 @@ na_ofi_endpoint_close(struct na_ofi_endpoint *na_ofi_endpoint)
     }
 
     /* Free OFI info */
-    if (na_ofi_endpoint->noe_prov)
+    if (na_ofi_endpoint->noe_prov) {
         fi_freeinfo(na_ofi_endpoint->noe_prov);
+        na_ofi_endpoint->noe_prov = NULL;
+    }
 
     free(na_ofi_endpoint->noe_node);
     free(na_ofi_endpoint->noe_service);
@@ -1858,17 +1863,23 @@ na_ofi_finalize(na_class_t *na_class)
     }
 
     /* Close endpoint */
-    ret = na_ofi_endpoint_close(priv->nop_endpoint);
-    if (ret != NA_SUCCESS) {
-        NA_LOG_ERROR("Could not close endpoint");
-        goto out;
+    if (priv->nop_endpoint) {
+        ret = na_ofi_endpoint_close(priv->nop_endpoint);
+        if (ret != NA_SUCCESS) {
+            NA_LOG_ERROR("Could not close endpoint");
+            goto out;
+        }
+        priv->nop_endpoint = NULL;
     }
 
     /* Close domain */
-    ret = na_ofi_domain_close(priv->nop_domain);
-    if (ret != NA_SUCCESS) {
-        NA_LOG_ERROR("Could not close domain");
-        goto out;
+    if (priv->nop_domain) {
+        ret = na_ofi_domain_close(priv->nop_domain);
+        if (ret != NA_SUCCESS) {
+            NA_LOG_ERROR("Could not close domain");
+            goto out;
+        }
+        priv->nop_domain = NULL;
     }
 
     /* Close mutex / free private data */


### PR DESCRIPTION
If a provider is unable to initialize properly
when creating an endpoint or domain, the OFI NA
wasn't handling cleanup of OFI info objects quite
right, resulting in heap corruption with double
frees, etc.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>