### PR TITLE
NA CCI: Added error handling when cci_connect() fails

### DIFF
--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -831,6 +831,10 @@ na_cci_addr_lookup(na_class_t * na_class, na_context_t * context,
     if (rc) {
         NA_LOG_ERROR("cci_connect(%s) failed with %s", name,
             cci_strerror(e, rc));
+        if (rc == CCI_ETIMEDOUT)
+            ret = NA_TIMEOUT;
+        else
+            ret = NA_CANCELED;
         goto out;
     }
 


### PR DESCRIPTION
When `na_cci_addr_lookup()` is eventually called from `HG_Addr_lookup()`, the function `cci_connect()` can return an error which is currently not handled. As a result, clients receive `HG_SUCCESS` when calling `HG_Addr_lookup()` although it has failed. This patch returns the appropriate error message for two cases: (1) `cci_connect()` timed out, or (2) other errors.

We faced this situation, while using CCI with the verbs plugin, when many clients called `HG_Addr_lookup()` to the same servers, essentially overwhelming the server to respond in time. The following error message was produced on the client side, with `HG_Addr_lookup()` returning `HG_SUCCESS`:

```
 # na_cci_addr_lookup(): cci_connect(verbs://a0357-ib:4433) failed with CCI_ETIMEDOUT
# NA -- Error -- /some/path/mercury/src/na/na_cci.c:833
```

Note, that `cci_connect()` can be given an optional timeout value (currently set to `NULL` in `na_cci_addr_lookup()`, i.e., wait forever according to documentation), which is not used in `cci_connect()`.