### PR TITLE
HG_Registered_proc_cb

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -1205,6 +1205,35 @@ HG_Registered(hg_class_t *hg_class, hg_id_t id, hg_bool_t *flag)
     return HG_Core_registered(hg_class, id, flag);
 }
 
+hg_return_t
+HG_Registered_proc_cb(
+        hg_class_t *hg_class,
+        hg_id_t id,
+        hg_bool_t *flag,
+        hg_proc_cb_t* in_proc_cb,
+        hg_proc_cb_t* out_proc_cb)
+{
+    struct hg_proc_info *hg_proc_info = NULL;
+    hg_return_t ret;
+
+    ret = HG_Core_registered(hg_class, id, flag);
+    
+    /* if RPC is registered, retrieve pointers */
+    if(ret == HG_SUCCESS && *flag) {
+        hg_proc_info =
+            (struct hg_proc_info *) HG_Core_registered_data(hg_class, id);
+        if (!hg_proc_info) {
+            HG_LOG_ERROR("Could not get registered data");
+            return(HG_NO_MATCH);
+        }
+        *in_proc_cb = hg_proc_info->in_proc_cb;
+        *out_proc_cb = hg_proc_info->out_proc_cb;
+    }
+
+    return ret;
+}
+
+
 /*---------------------------------------------------------------------------*/
 hg_return_t
 HG_Register_data(hg_class_t *hg_class, hg_id_t id, void *data,

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -376,6 +376,27 @@ HG_Registered(
         );
 
 /**
+ * Indicate whether HG_Register() has been called, and if so return pointers
+ * to cb functions for the RPC.
+ *
+ * \param hg_class [IN]         pointer to HG class
+ * \param id [IN]               function ID
+ * \param flag [OUT]            pointer to boolean
+ * \param in_proc_cb [OUT]      pointer to input encoder cb
+ * \param out_proc_cb [OUT]     pointer to output encoder cb
+ *
+ * \return HG_SUCCESS or corresponding HG error code
+ */
+HG_EXPORT hg_return_t
+HG_Registered_proc_cb(
+        hg_class_t *hg_class,
+        hg_id_t id,
+        hg_bool_t *flag,
+        hg_proc_cb_t* in_proc_cb,
+        hg_proc_cb_t* out_proc_cb
+        );
+
+/**
  * Register and associate user data to registered function. When HG_Finalize()
  * is called, free_callback (if defined) is called to free the registered
  * data.

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -4504,7 +4504,6 @@ HG_Core_reset(hg_handle_t handle, hg_addr_t addr, hg_id_t id)
     /* Set addr / RPC ID */
     ret = hg_core_set_rpc(hg_handle, addr, id);
     if (ret != HG_SUCCESS) {
-        HG_LOG_ERROR("Could not set rpc to handle");
         goto done;
     }
 

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1934,7 +1934,6 @@ hg_core_set_rpc(struct hg_handle *hg_handle, hg_addr_t addr, hg_id_t id)
     if (id && hg_handle->hg_info.id != id) {
         struct hg_rpc_info *hg_rpc_info;
         hg_context_t *context = hg_handle->hg_info.context;
-        hg_handle->hg_info.id = id;
 
         /* Retrieve ID function from function map */
         hg_thread_spin_lock(&context->hg_class->func_map_lock);
@@ -1942,10 +1941,10 @@ hg_core_set_rpc(struct hg_handle *hg_handle, hg_addr_t addr, hg_id_t id)
             context->hg_class->func_map, (hg_hash_table_key_t) &id);
         hg_thread_spin_unlock(&context->hg_class->func_map_lock);
         if (!hg_rpc_info) {
-            HG_LOG_ERROR("Could not find RPC ID in function map");
             ret = HG_NO_MATCH;
             goto done;
         }
+        hg_handle->hg_info.id = id;
 
         /* Cache RPC info */
         hg_handle->hg_rpc_info = hg_rpc_info;


### PR DESCRIPTION
Adds a new API call, HG_Registered_proc_cb(), which is identical to HG_Registered except that if the RPC has been registered it returns pointers to the input and output encoder callbacks. 

PR also includes less verbose explicit error messages in the set_rpc() code path, so that failure to reset a handle because the hg_id_t has not been registered yet can be a gracefully recovered error instead of a critical error. 

Also a bug fix to the set_rpc() path to make sure that it does not modify the caller's output arguments unless the call is successful.

The purpose of this set of changes is to enable the following pattern: a client attempts to use an hg_id_t that hasn't been registered yet, then falls back to register it on the fly, reusing encoders from an existing hg_id_t that is known to have the same wire protocol.  This will be used for dynamic registration of new hg_id_ts that are being multiplexed for service-specific reasons on the server.