### PR TITLE
added HG_Registered_disable_response function to check if response is…

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -1728,6 +1728,39 @@ done:
 
 /*---------------------------------------------------------------------------*/
 hg_return_t
+HG_Registered_disabled_response(hg_class_t *hg_class, hg_id_t id,
+    hg_bool_t* disabled)
+{
+    struct hg_proc_info *hg_proc_info = NULL;
+    hg_return_t ret = HG_SUCCESS;
+
+    if (!hg_class) {
+        HG_LOG_ERROR("NULL HG class");
+        ret = HG_INVALID_PARAM;
+        goto done;
+    }
+
+    hg_thread_spin_lock(&hg_class->register_lock);
+
+    /* Retrieve proc function from function map */
+    hg_proc_info = (struct hg_proc_info *) HG_Core_registered_data(
+        hg_class->core_class, id);
+    if (!hg_proc_info) {
+        HG_LOG_ERROR("Could not get registered data");
+        ret = HG_NO_MATCH;
+        hg_thread_spin_unlock(&hg_class->register_lock);
+        goto done;
+    }
+
+    *disabled = hg_proc_info->no_response;
+
+    hg_thread_spin_unlock(&hg_class->register_lock);
+
+done:
+    return ret;
+}
+/*---------------------------------------------------------------------------*/
+hg_return_t
 HG_Addr_lookup(hg_context_t *context, hg_cb_t callback, void *arg,
     const char *name, hg_op_id_t *op_id)
 {

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -529,6 +529,24 @@ HG_Registered_disable_response(
         );
 
 /**
+ * Check if response is disabled for a given RPC ID
+ * (i.e. HG_Registered_disable_response has been called for this RPC ID).
+ *
+ * \param hg_class [IN]         pointer to HG class
+ * \param id [IN]               registered function ID
+ * \param disabled [OUT]        boolean (HG_TRUE if disabled
+ *                                       HG_FALSE if enabled)
+ *
+ * \return HG_SUCCESS or corresponding HG error code
+ */
+HG_EXPORT hg_return_t
+HG_Registered_disabled_response(
+        hg_class_t *hg_class,
+        hg_id_t id,
+        hg_bool_t* disabled
+        );
+
+/**
  * Lookup an addr from a peer address/name. Addresses need to be
  * freed by calling HG_Addr_free(). After completion, user callback is
  * placed into a completion queue and can be triggered using HG_Trigger().


### PR DESCRIPTION
This new function can be used to check if response is disabled for a given RPC ID.