### PR TITLE
unify verbs and verbs;ofi_rxm path in na_ofi

### DIFF
--- a/Testing/na/na_test.c
+++ b/Testing/na/na_test.c
@@ -299,6 +299,7 @@ na_test_gen_config(struct na_test_info *na_test_info)
         }
     } else if ((strcmp("tcp", na_test_info->protocol) == 0)
         || (strcmp("verbs;ofi_rxm", na_test_info->protocol) == 0)
+        || (strcmp("verbs", na_test_info->protocol) == 0)
         || (strcmp("psm2", na_test_info->protocol) == 0)
         || (strcmp("sockets", na_test_info->protocol) == 0)) {
         if (na_test_info->listen) {

--- a/Testing/na/na_test.c
+++ b/Testing/na/na_test.c
@@ -298,7 +298,6 @@ na_test_gen_config(struct na_test_info *na_test_info)
             sprintf(info_string_ptr, "://%d/%d", (int) getpid(), port_incr);
         }
     } else if ((strcmp("tcp", na_test_info->protocol) == 0)
-        || (strcmp("verbs", na_test_info->protocol) == 0)
         || (strcmp("verbs;ofi_rxm", na_test_info->protocol) == 0)
         || (strcmp("psm2", na_test_info->protocol) == 0)
         || (strcmp("sockets", na_test_info->protocol) == 0)) {

--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -2185,8 +2185,11 @@ na_ofi_check_protocol(const char *protocol_name)
 
     /* In case of sockets, protocol used is TCP but allow for passing provider
      * name directly, will use TCP by default */
+    /* We also translate "verbs" to "verbs;ofi_rxm" */
     if (!strcmp(protocol_name, "tcp"))
         prov_name = NA_OFI_PROV_SOCKETS_NAME;
+    else if(!strcmp(protocol_name, "verbs"))
+        prov_name = NA_OFI_PROV_VERBS_NAME;
     else
         prov_name = protocol_name;
 
@@ -2239,8 +2242,11 @@ na_ofi_initialize(na_class_t *na_class, const struct na_info *na_info,
 
     /* In case of sockets, protocol used is TCP but allow for passing provider
      * name directly, will use TCP by default */
+    /* We also translate "verbs" to "verbs;ofi_rxm" */
     if (!strcmp(na_info->protocol_name, "tcp"))
         prov_name = NA_OFI_PROV_SOCKETS_NAME;
+    else if(!strcmp(na_info->protocol_name, "verbs"))
+        prov_name = NA_OFI_PROV_VERBS_NAME;
     else
         prov_name = na_info->protocol_name;
 


### PR DESCRIPTION
Fixes #236 .

Does not resolve any other correctness issues, just gives us a cleaner starting point.