### PR TITLE
Bulk: bind HG addr to bulk handle and NA OFI addressing fixes

### DIFF
--- a/Testing/mercury_rpc_cb.h
+++ b/Testing/mercury_rpc_cb.h
@@ -28,6 +28,8 @@ hg_test_rpc_open_no_resp_cb(hg_handle_t handle);
  */
 hg_return_t
 hg_test_bulk_write_cb(hg_handle_t handle);
+hg_return_t
+hg_test_bulk_bind_write_cb(hg_handle_t handle);
 
 ///**
 // * test_pipeline

--- a/Testing/mercury_test.c
+++ b/Testing/mercury_test.c
@@ -72,6 +72,7 @@ hg_id_t hg_test_rpc_open_id_no_resp_g = 0;
 
 /* test_bulk */
 hg_id_t hg_test_bulk_write_id_g = 0;
+hg_id_t hg_test_bulk_bind_write_id_g = 0;
 
 /* test_pipeline */
 hg_id_t hg_test_pipeline_write_id_g = 0;
@@ -277,6 +278,9 @@ hg_test_register(hg_class_t *hg_class)
     /* test_bulk */
     hg_test_bulk_write_id_g = MERCURY_REGISTER(hg_class, "hg_test_bulk_write",
             bulk_write_in_t, bulk_write_out_t, hg_test_bulk_write_cb);
+    hg_test_bulk_bind_write_id_g = MERCURY_REGISTER(hg_class,
+        "hg_test_bulk_bind_write", bulk_write_in_t, bulk_bind_write_out_t,
+        hg_test_bulk_bind_write_cb);
 
 #ifndef _WIN32
     /* test_posix */

--- a/Testing/na/na_test.c
+++ b/Testing/na/na_test.c
@@ -415,6 +415,11 @@ NA_Test_init(int argc, char *argv[], struct na_test_info *na_test_info)
     printf("# Using info string: %s\n", info_string);
     na_test_info->na_class = NA_Initialize_opt(info_string,
         na_test_info->listen, &na_init_info);
+    if (!na_test_info->na_class) {
+        NA_LOG_ERROR("Could not initialize NA");
+        ret = NA_PROTOCOL_ERROR;
+        goto done;
+    }
 
     if (!na_test_info->extern_init) {
         if (na_test_info->listen) {
@@ -472,6 +477,8 @@ NA_Test_init(int argc, char *argv[], struct na_test_info *na_test_info)
     }
 
 done:
+    if (ret != NA_SUCCESS)
+        NA_Test_finalize(na_test_info);
     free(info_string);
     return ret;
 }

--- a/Testing/test_bulk.c
+++ b/Testing/test_bulk.c
@@ -561,14 +561,16 @@ int main(int argc, char *argv[])
     }
     HG_PASSED();
 
-    HG_TEST("bind contiguous RPC bulk (size BUFSIZE, offsets 0, 0)");
-    hg_ret = hg_test_bulk_contig(hg_test_info.hg_class, hg_test_info.context,
-        hg_test_info.request_class, 1, hg_test_info.target_addr, BUFSIZE, 0, 0);
-    if (hg_ret != HG_SUCCESS) {
-        ret = EXIT_FAILURE;
-        goto done;
+    if (strcmp(HG_Class_get_name(hg_test_info.hg_class), "ofi") == 0) {
+        HG_TEST("bind contiguous RPC bulk (size BUFSIZE, offsets 0, 0)");
+        hg_ret = hg_test_bulk_contig(hg_test_info.hg_class, hg_test_info.context,
+            hg_test_info.request_class, 1, hg_test_info.target_addr, BUFSIZE, 0, 0);
+        if (hg_ret != HG_SUCCESS) {
+            ret = EXIT_FAILURE;
+            goto done;
+        }
+        HG_PASSED();
     }
-    HG_PASSED();
 
 done:
     if (ret != EXIT_SUCCESS)

--- a/Testing/test_bulk.c
+++ b/Testing/test_bulk.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 extern hg_id_t hg_test_bulk_write_id_g;
+extern hg_id_t hg_test_bulk_bind_write_id_g;
 
 #define BUFSIZE (MERCURY_TESTING_BUFFER_SIZE * 1024 * 1024)
 
@@ -78,9 +79,52 @@ done:
 
 /*---------------------------------------------------------------------------*/
 static hg_return_t
+hg_test_bulk_bind_forward_cb(const struct hg_cb_info *callback_info)
+{
+    hg_handle_t handle = callback_info->info.forward.handle;
+    struct forward_cb_args *args = (struct forward_cb_args *) callback_info->arg;
+    size_t bulk_write_ret = 0;
+    bulk_bind_write_out_t bulk_write_out_struct;
+    hg_return_t ret = HG_SUCCESS;
+
+    if (callback_info->ret != HG_SUCCESS) {
+        HG_TEST_LOG_ERROR("Return from callback info is not HG_SUCCESS");
+        goto done;
+    }
+
+    /* Get output */
+    ret = HG_Get_output(handle, &bulk_write_out_struct);
+    if (ret != HG_SUCCESS) {
+        HG_TEST_LOG_ERROR("Could not get output");
+        goto done;
+    }
+
+    /* Get output parameters */
+    bulk_write_ret = bulk_write_out_struct.ret;
+    if (bulk_write_ret != args->expected_bytes) {
+        HG_TEST_LOG_ERROR("Returned: %zu bytes, was expecting %zu",
+            bulk_write_ret, args->expected_bytes);
+        args->ret = HG_SIZE_ERROR;
+    }
+
+    /* Free request */
+    ret = HG_Free_output(handle, &bulk_write_out_struct);
+    if (ret != HG_SUCCESS) {
+        HG_TEST_LOG_ERROR("Could not free output");
+        goto done;
+    }
+
+done:
+    hg_request_complete(args->request);
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+static hg_return_t
 hg_test_bulk_contig(hg_class_t *hg_class, hg_context_t *context,
-    hg_request_class_t *request_class, hg_addr_t target_addr,
-    hg_size_t transfer_size, hg_size_t origin_offset, hg_size_t target_offset)
+    hg_request_class_t *request_class, hg_bool_t bind_addr,
+    hg_addr_t target_addr, hg_size_t transfer_size, hg_size_t origin_offset,
+    hg_size_t target_offset)
 {
     hg_request_t *request = NULL;
     hg_handle_t handle;
@@ -92,6 +136,8 @@ hg_test_bulk_contig(hg_class_t *hg_class, hg_context_t *context,
     void *buf_ptrs[2];
     hg_size_t buf_sizes[2];
     hg_size_t bulk_size = BUFSIZE;
+    hg_id_t rpc_id = hg_test_bulk_write_id_g;
+    hg_cb_t forward_cb = hg_test_bulk_forward_cb;
     size_t i;
 
     if (origin_offset + transfer_size > bulk_size) {
@@ -111,17 +157,31 @@ hg_test_bulk_contig(hg_class_t *hg_class, hg_context_t *context,
 
     request = hg_request_create(request_class);
 
-    ret = HG_Create(context, target_addr, hg_test_bulk_write_id_g, &handle);
-    if (ret != HG_SUCCESS) {
-        HG_TEST_LOG_ERROR("Could not create handle");
-        goto done;
-    }
-
     /* Register memory */
     ret = HG_Bulk_create(hg_class, 2, buf_ptrs, buf_sizes, HG_BULK_READ_ONLY,
         &bulk_handle);
     if (ret != HG_SUCCESS) {
         HG_TEST_LOG_ERROR("Could not create bulk handle");
+        goto done;
+    }
+
+    if (bind_addr) {
+        /* Bind local context to bulk, it is only necessary if this bulk handle
+         * will be shared to another server by the server of this RPC, but it
+         * should also work for normal case. Add here just to test the
+         * functionality. */
+        ret = HG_Bulk_bind(bulk_handle, context);
+        if (ret != HG_SUCCESS) {
+            HG_TEST_LOG_ERROR("Could not bind context to bulk handle");
+            goto done;
+        }
+        rpc_id = hg_test_bulk_bind_write_id_g;
+        forward_cb = hg_test_bulk_bind_forward_cb;
+    }
+
+    ret = HG_Create(context, target_addr, rpc_id, &handle);
+    if (ret != HG_SUCCESS) {
+        HG_TEST_LOG_ERROR("Could not create handle");
         goto done;
     }
 
@@ -136,13 +196,12 @@ hg_test_bulk_contig(hg_class_t *hg_class, hg_context_t *context,
         bulk_write_in_struct.origin_offset, bulk_write_in_struct.target_offset);
 
     /* Forward call to remote addr and get a new request */
-    HG_TEST_LOG_DEBUG("Forwarding call with op id: %u...",
-        hg_test_bulk_write_id_g);
+    HG_TEST_LOG_DEBUG("Forwarding call with op id: %u...", rpc_id);
     forward_cb_args.request = request;
     forward_cb_args.expected_bytes = transfer_size;
     forward_cb_args.ret = HG_SUCCESS;
-    ret = HG_Forward(handle, hg_test_bulk_forward_cb, &forward_cb_args,
-            &bulk_write_in_struct);
+    ret = HG_Forward(handle, forward_cb, &forward_cb_args,
+        &bulk_write_in_struct);
     if (ret != HG_SUCCESS) {
         HG_TEST_LOG_ERROR("Could not forward call");
         goto done;
@@ -388,7 +447,7 @@ int main(int argc, char *argv[])
     /* Simple RPC bulk test */
     HG_TEST("contiguous RPC bulk (size BUFSIZE, offsets 0, 0)");
     hg_ret = hg_test_bulk_contig(hg_test_info.hg_class, hg_test_info.context,
-        hg_test_info.request_class, hg_test_info.target_addr, BUFSIZE, 0, 0);
+        hg_test_info.request_class, 0, hg_test_info.target_addr, BUFSIZE, 0, 0);
     if (hg_ret != HG_SUCCESS) {
         ret = EXIT_FAILURE;
         goto done;
@@ -397,7 +456,7 @@ int main(int argc, char *argv[])
 
     HG_TEST("contiguous RPC bulk (size BUFSIZE/4, offsets BUFSIZE/2 + 1, 0)");
     hg_ret = hg_test_bulk_contig(hg_test_info.hg_class, hg_test_info.context,
-        hg_test_info.request_class, hg_test_info.target_addr, BUFSIZE/4,
+        hg_test_info.request_class, 0, hg_test_info.target_addr, BUFSIZE/4,
         BUFSIZE/2 + 1, 0);
     if (hg_ret != HG_SUCCESS) {
         ret = EXIT_FAILURE;
@@ -407,7 +466,7 @@ int main(int argc, char *argv[])
 
     HG_TEST("contiguous RPC bulk (size BUFSIZE/8, offsets BUFSIZE/2 + 1, BUFSIZE/4)");
     hg_ret = hg_test_bulk_contig(hg_test_info.hg_class, hg_test_info.context,
-        hg_test_info.request_class, hg_test_info.target_addr, BUFSIZE/8,
+        hg_test_info.request_class, 0, hg_test_info.target_addr, BUFSIZE/8,
         BUFSIZE/2 + 1, BUFSIZE/4);
     if (hg_ret != HG_SUCCESS) {
         ret = EXIT_FAILURE;
@@ -496,6 +555,15 @@ int main(int argc, char *argv[])
     hg_ret = hg_test_bulk_seg(hg_test_info.hg_class, hg_test_info.context,
         hg_test_info.request_class, hg_test_info.target_addr, BUFSIZE/8,
         BUFSIZE/2 + 1, BUFSIZE/4, 1024);
+    if (hg_ret != HG_SUCCESS) {
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+    HG_PASSED();
+
+    HG_TEST("bind contiguous RPC bulk (size BUFSIZE, offsets 0, 0)");
+    hg_ret = hg_test_bulk_contig(hg_test_info.hg_class, hg_test_info.context,
+        hg_test_info.request_class, 1, hg_test_info.target_addr, BUFSIZE, 0, 0);
     if (hg_ret != HG_SUCCESS) {
         ret = EXIT_FAILURE;
         goto done;

--- a/Testing/test_bulk.h
+++ b/Testing/test_bulk.h
@@ -25,6 +25,8 @@ MERCURY_GEN_PROC(bulk_write_in_t,
     ((hg_size_t)(origin_offset)) ((hg_size_t)(target_offset))
     ((hg_bulk_t)(bulk_handle)))
 MERCURY_GEN_PROC(bulk_write_out_t, ((hg_size_t)(ret)))
+MERCURY_GEN_PROC(bulk_bind_write_out_t,
+    ((hg_size_t)(ret)) ((hg_bulk_t)(bulk_handle)))
 #else
 /* Define bulk_write_in_t */
 typedef struct {
@@ -88,6 +90,34 @@ hg_proc_bulk_write_out_t(hg_proc_t proc, void *data)
     bulk_write_out_t *struct_data = (bulk_write_out_t *) data;
 
     ret = hg_proc_hg_size_t(proc, &struct_data->ret);
+    if (ret != HG_SUCCESS) {
+        HG_LOG_ERROR("Proc error");
+        return ret;
+    }
+
+    return ret;
+}
+
+/* Define bulk_write_out_t */
+typedef struct {
+    hg_size_t ret;
+    hg_bulk_t bulk_handle;
+} bulk_bind_write_out_t;
+
+/* Define hg_proc_bulk_write_out_t */
+static HG_INLINE hg_return_t
+hg_proc_bulk_bind_write_out_t(hg_proc_t proc, void *data)
+{
+    hg_return_t ret = HG_SUCCESS;
+    bulk_bind_write_out_t *struct_data = (bulk_bind_write_out_t *) data;
+
+    ret = hg_proc_hg_size_t(proc, &struct_data->ret);
+    if (ret != HG_SUCCESS) {
+        HG_LOG_ERROR("Proc error");
+        return ret;
+    }
+
+    ret = hg_proc_hg_bulk_t(proc, &struct_data->bulk_handle);
     if (ret != HG_SUCCESS) {
         HG_LOG_ERROR("Proc error");
         return ret;

--- a/Testing/test_server.c
+++ b/Testing/test_server.c
@@ -86,7 +86,9 @@ main(int argc, char *argv[])
 
     /* Force to listen */
     hg_test_info.na_test_info.listen = NA_TRUE;
-    HG_Test_init(argc, argv, &hg_test_info);
+    ret = HG_Test_init(argc, argv, &hg_test_info);
+    if (ret != HG_SUCCESS)
+        return EXIT_FAILURE;
 
     hg_test_context_info =
         (struct hg_test_context_info *) HG_Context_get_data(

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -536,6 +536,18 @@ HG_Core_addr_lookup(
         );
 
 /**
+ * Create a HG core address.
+ *
+ * \param hg_core_class [IN]    pointer to HG core class
+ *
+ * \return created abstract HG core address or HG_CORE_ADDR_NULL if failed.
+ */
+HG_EXPORT hg_core_addr_t
+HG_Core_addr_create(
+        hg_core_class_t *hg_core_class
+        );
+
+/**
  * Free the addr from the list of peers.
  *
  * \param hg_core_class [IN]    pointer to HG core class
@@ -547,6 +559,18 @@ HG_EXPORT hg_return_t
 HG_Core_addr_free(
         hg_core_class_t *hg_core_class,
         hg_core_addr_t addr
+        );
+
+/**
+ * Set the underlying NA address to a HG address.
+ *
+ * \param core_addr [IN]        abstract address that not set NA address before
+ * \param na_addr [IN]          abstract NA addr
+ */
+HG_EXPORT void
+HG_Core_addr_set_na(
+        hg_core_addr_t core_addr,
+        na_addr_t na_addr
         );
 
 /**

--- a/src/na/na.c
+++ b/src/na/na.c
@@ -896,6 +896,109 @@ done:
 
 /*---------------------------------------------------------------------------*/
 na_size_t
+NA_Addr_get_serialize_size(na_class_t *na_class, na_addr_t addr)
+{
+    na_size_t ret = 0;
+
+    if (!na_class) {
+        NA_LOG_ERROR("NULL NA class");
+        goto done;
+    }
+    if (addr == NA_ADDR_NULL) {
+        NA_LOG_ERROR("NULL addr");
+        goto done;
+    }
+    if (!na_class->addr_get_serialize_size) {
+        NA_LOG_ERROR("addr_get_serialize_size plugin callback is not defined");
+        goto done;
+    }
+
+    ret = na_class->addr_get_serialize_size(na_class, addr);
+
+done:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
+NA_Addr_serialize(na_class_t *na_class, void *buf, na_size_t buf_size,
+    na_addr_t addr)
+{
+    na_return_t ret = NA_SUCCESS;
+
+    if (!na_class) {
+        NA_LOG_ERROR("NULL NA class");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!buf) {
+        NA_LOG_ERROR("NULL buffer");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!buf_size) {
+        NA_LOG_ERROR("NULL buffer size");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (addr == NA_ADDR_NULL) {
+        NA_LOG_ERROR("NULL addr");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!na_class->addr_serialize) {
+        NA_LOG_ERROR("addr_serialize plugin callback is not defined");
+        ret = NA_PROTOCOL_ERROR;
+        goto done;
+    }
+
+    ret = na_class->addr_serialize(na_class, buf, buf_size, addr);
+
+done:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
+NA_Addr_deserialize(na_class_t *na_class, na_addr_t *addr, const void *buf,
+    na_size_t buf_size)
+{
+    na_return_t ret = NA_SUCCESS;
+
+    if (!na_class) {
+        NA_LOG_ERROR("NULL NA class");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!addr) {
+        NA_LOG_ERROR("NULL pointer to addr");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!buf) {
+        NA_LOG_ERROR("NULL buffer");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!buf_size) {
+        NA_LOG_ERROR("NULL buffer size");
+        ret = NA_INVALID_PARAM;
+        goto done;
+    }
+    if (!na_class->addr_deserialize) {
+        NA_LOG_ERROR("addr_deserialize plugin callback is not defined");
+        ret = NA_PROTOCOL_ERROR;
+        goto done;
+    }
+
+    ret = na_class->addr_deserialize(na_class, addr, buf, buf_size);
+
+done:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+na_size_t
 NA_Msg_get_max_unexpected_size(const na_class_t *na_class)
 {
     na_size_t ret = 0;

--- a/src/na/na.h
+++ b/src/na/na.h
@@ -410,6 +410,57 @@ NA_Addr_to_string(
         );
 
 /**
+ * Get size required to serialize address.
+ *
+ * \param na_class [IN/OUT]     pointer to NA class
+ * \param addr [IN]             abstract address
+ *
+ * \return Non-negative value
+ */
+NA_EXPORT na_size_t
+NA_Addr_get_serialize_size(
+        na_class_t  *na_class,
+        na_addr_t    addr
+        ) NA_WARN_UNUSED_RESULT;
+
+/**
+ * Serialize address into a buffer.
+ *
+ * \param na_class [IN/OUT]     pointer to NA class
+ * \param buf [IN/OUT]          pointer to buffer used for serialization
+ * \param buf_size [IN]         buffer size
+ * \param addr [IN]             abstract address
+ *
+ * \return NA_SUCCESS or corresponding NA error code
+ */
+NA_EXPORT na_return_t
+NA_Addr_serialize(
+        na_class_t  *na_class,
+        void        *buf,
+        na_size_t    buf_size,
+        na_addr_t    addr
+        );
+
+/**
+ * Deserialize address from a buffer. The returned address must be freed with
+ * NA_Addr_free().
+ *
+ * \param na_class [IN/OUT]     pointer to NA class
+ * \param addr [OUT]            pointer to abstract address
+ * \param buf [IN]              pointer to buffer used for deserialization
+ * \param buf_size [IN]         buffer size
+ *
+ * \return NA_SUCCESS or corresponding NA error code
+ */
+NA_EXPORT na_return_t
+NA_Addr_deserialize(
+        na_class_t      *na_class,
+        na_addr_t       *addr,
+        const void      *buf,
+        na_size_t        buf_size
+        );
+
+/**
  * Get the maximum size of messages supported by unexpected send/recv.
  * Small message size.
  *

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -523,6 +523,9 @@ const na_class_t na_bmi_class_g = {
         na_bmi_addr_dup,                      /* addr_dup */
         na_bmi_addr_is_self,                  /* addr_is_self */
         na_bmi_addr_to_string,                /* addr_to_string */
+        NULL,                                 /* addr_get_serialize_size */
+        NULL,                                 /* addr_serialize */
+        NULL,                                 /* addr_deserialize */
         na_bmi_msg_get_max_unexpected_size,   /* msg_get_max_unexpected_size */
         na_bmi_msg_get_max_expected_size,     /* msg_get_max_expected_size */
         NULL,                                 /* msg_get_unexpected_header_size */

--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -381,6 +381,9 @@ const na_class_t na_cci_class_g = {
     na_cci_addr_dup,                        /* addr_dup */
     na_cci_addr_is_self,                    /* addr_is_self */
     na_cci_addr_to_string,                  /* addr_to_string */
+    NULL,                                   /* addr_get_serialize_size */
+    NULL,                                   /* addr_serialize */
+    NULL,                                   /* addr_deserialize */
     na_cci_msg_get_max_unexpected_size,     /* msg_get_max_unexpected_size */
     na_cci_msg_get_max_expected_size,       /* msg_get_max_expected_size */
     NULL,                                   /* msg_get_unexpected_header_size */

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -554,6 +554,9 @@ const na_class_t na_mpi_class_g = {
         NULL,                                 /* addr_dup */
         na_mpi_addr_is_self,                  /* addr_is_self */
         na_mpi_addr_to_string,                /* addr_to_string */
+        NULL,                                 /* addr_get_serialize_size */
+        NULL,                                 /* addr_serialize */
+        NULL,                                 /* addr_deserialize */
         na_mpi_msg_get_max_unexpected_size,   /* msg_get_max_unexpected_size */
         na_mpi_msg_get_max_expected_size,     /* msg_get_max_expected_size */
         NULL,                                 /* msg_get_unexpected_header_size */

--- a/src/na/na_private.h
+++ b/src/na/na_private.h
@@ -130,6 +130,25 @@ struct na_class {
             na_addr_t   addr
             );
     na_size_t
+    (*addr_get_serialize_size)(
+            na_class_t      *na_class,
+            na_addr_t        addr
+            );
+    na_return_t
+    (*addr_serialize)(
+            na_class_t      *na_class,
+            void            *buf,
+            na_size_t        buf_size,
+            na_addr_t        addr
+    );
+    na_return_t
+    (*addr_deserialize)(
+            na_class_t      *na_class,
+            na_addr_t       *addr,
+            const void      *buf,
+            na_size_t        buf_size
+    );
+    na_size_t
     (*msg_get_max_unexpected_size)(
             const na_class_t *na_class
             );
@@ -363,6 +382,16 @@ struct na_class {
 #if !defined(container_of)
 # define container_of(ptr, type, member) \
     ((type *) ((char *) ptr - offsetof(type, member)))
+#endif
+
+/**
+ * Min/max macros
+ */
+#ifndef MAX
+# define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef MIN
+# define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 /*********************/

--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -894,6 +894,9 @@ const na_class_t na_sm_class_g = {
     na_sm_addr_dup,                         /* addr_dup */
     na_sm_addr_is_self,                     /* addr_is_self */
     na_sm_addr_to_string,                   /* addr_to_string */
+    NULL,                                   /* addr_get_serialize_size */
+    NULL,                                   /* addr_serialize */
+    NULL,                                   /* addr_deserialize */
     na_sm_msg_get_max_unexpected_size,      /* msg_get_max_unexpected_size */
     na_sm_msg_get_max_expected_size,        /* msg_get_max_expected_size */
     NULL,                                   /* msg_get_unexpected_header_size */


### PR DESCRIPTION
HG Bulk: 
- add HG_Bulk_bind(), HG_Bulk_get_addr(), HG_Bulk_get_context_id()
- also add HG_Bulk_bind_transfer() for convenience

HG Bulk proc:
- enable caching of serialized bulk handles / cleanup

HG Core:
- add HG_Core_addr_create() and HG_Core_addr_set_na()
    
NA: 
- add NA_Addr_serialize()/NA_Addr_deserialize()/get_serialize_size() and corresponding plugin callbacks

NA OFI:
- Add na_ofi_addr_serialize() plugin callback implementation
- Rework address handling to only use native addressing format
- Fix passing of init node and domain info in na_ofi_initialize()
- Fix socket provider to bind to specific host/port (fix #207)
- Update gni provider to use FI_SOURCE | FI_SOURCE_ERR caps
- Rework and clean up na_ofi_progress()
- Allocate src_err_addr for fi_cq_readerr()
- Clean up NA OFI op ID and na_ofi_complete()
- Clean up NA OFI plugin and add missing NA_INLINE / prototypes
- Remove unused macros

Testing:
- update bulk test for bind addr testing / clean up return codes