### PR TITLE
fix: CMake silently ignore SM auto routing option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,8 @@ if(MERCURY_USE_SM_ROUTING)
       ${MERCURY_EXT_LIB_DEPENDENCIES}
       ${UUID_LIBRARIES}
     )
+  else()
+	  message(FATAL_ERROR "SM_ROUTING cannot be supported because LibUUID couldn't be found")
   endif()
   if(MERCURY_USE_SM_ROUTING AND NOT NA_USE_SM)
     # Always force SM if NA_USE_SM is turned OFF


### PR DESCRIPTION
If LibUUID was not found by cmake the `MERCURY_USE_SM_ROUTING` was silently ignored.

CMake would now throw an error explaining that SM auto routing cannot be supported without LibUUID.

fix #258 