### PR TITLE
enable wait_fd and auto progress for psm2

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -142,10 +142,10 @@
         "psm2",                                                         \
         "",                                                             \
         FI_ADDR_PSMX2,                                                  \
-        FI_PROGRESS_MANUAL,                                             \
+        FI_PROGRESS_AUTO,                                               \
         FI_MR_BASIC,                                                    \
         (FI_SOURCE | FI_SOURCE_ERR | FI_DIRECTED_RECV),                 \
-        (NA_OFI_DOMAIN_LOCK)                                            \
+        (NA_OFI_DOMAIN_LOCK | NA_OFI_WAIT_FD)                           \
     )                                                                   \
     X(NA_OFI_PROV_VERBS,                                                \
         "verbs;ofi_rxm",                                                \


### PR DESCRIPTION
Tested on Bebop system at ANL/LCRC.  This sets the WAIT_FD option in na_ofi in combination with the AUTO progress mode (the former will not work without the latter).

Causes a penalty to latency but not throughput in exchange for reducing CPU consumption when not in busy spin mode.