### PR TITLE
fix bug in header encoding for null input

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -657,7 +657,7 @@ hg_set_struct(struct hg_private_handle *hg_handle,
     }
     if (!proc_cb || !struct_ptr) {
         /* Silently skip */
-        *payload_size = 0;
+        *payload_size = header_offset;
         goto done;
     }
 


### PR DESCRIPTION
- Don't skip too many header encoding steps if input struct and/or encoder is null.
- This fix ensures that Mercury includes the HG_Class_set_input_offset() area when transmitting RPCs with no input arguments.