### PR TITLE
allow NULL size argument to HG_Get_input_buf()

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -1971,7 +1971,7 @@ HG_Get_input_buf(hg_handle_t handle, void **in_buf, hg_size_t *in_buf_size)
         ret = HG_INVALID_PARAM;
         goto done;
     }
-    if (!in_buf || !in_buf_size) {
+    if (!in_buf) {
         HG_LOG_ERROR("NULL pointer");
         ret = HG_INVALID_PARAM;
         goto done;
@@ -1981,7 +1981,8 @@ HG_Get_input_buf(hg_handle_t handle, void **in_buf, hg_size_t *in_buf_size)
      * only the user payload is copied */
     if (private_handle->in_extra_buf) {
         *in_buf = private_handle->in_extra_buf;
-        *in_buf_size = private_handle->in_extra_buf_size;
+        if(in_buf_size)
+            *in_buf_size = private_handle->in_extra_buf_size;
     } else {
         void *buf;
         hg_size_t buf_size, header_offset = hg_header_get_size(HG_INPUT);
@@ -1994,7 +1995,8 @@ HG_Get_input_buf(hg_handle_t handle, void **in_buf, hg_size_t *in_buf_size)
         }
 
         *in_buf = (char *) buf + header_offset;
-        *in_buf_size = buf_size - header_offset;
+        if(in_buf_size)
+            *in_buf_size = buf_size - header_offset;
     }
 
 done:

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -858,6 +858,8 @@ HG_Free_output(
  * to define the offset at which HG_Forward() / HG_Get_input() will start
  * encoding / decoding the input parameters.
  *
+ * \remark in_buf_size argument will be ignored if NULL
+ *
  * \param handle [IN]           HG handle
  * \param in_buf [OUT]          pointer to input buffer
  * \param in_buf_size [OUT]     pointer to input buffer size


### PR DESCRIPTION
This is helpful for use cases where the caller doesn't need to know the buffer size and just wants to access the smaller region that they have reserved with HG_Class_set_input_offset().  

This patch does not change the semantics of the call for existing users.  It just allows new users to pass NULL for the last argument rather than declaring a dummy variable to hold the unwanted result.