### PR TITLE
input offset bugfix

### DIFF
--- a/src/mercury.h
+++ b/src/mercury.h
@@ -1125,6 +1125,10 @@ HG_Class_set_input_offset(hg_class_t *hg_class, hg_size_t offset)
         return HG_INVALID_PARAM;
     }
 #endif
+    /* extra input header must not be larger than eager size */
+    if(offset > HG_Class_get_input_eager_size(hg_class))
+        return HG_INVALID_PARAM;
+
     hg_class->in_offset = offset;
 
     return HG_SUCCESS;


### PR DESCRIPTION
Fixes #302 

The encoding of extra input header information was correct, it's just that the HG_Get_input_buf() function assumed that it had been moved to the extra_buf memory buffer if the request exceeded the eager limit.

This PR makes the encoder (hg_set_struct()) and the function for accessing the extra header (HG_Get_input_buf()) consistent in assuming the data is in the request.

It also adds a safety check to the HG_Class_set_input_offset(), because the extra header information cannot be larger than the eager buffer size.