### PR TITLE
refcount of na_ofi_op_id is overwritten

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -3648,8 +3648,6 @@ na_ofi_addr_lookup(na_class_t *na_class, na_context_t *context,
     na_ofi_op_id->noo_completion_data.callback_info.arg = arg;
     hg_atomic_set32(&na_ofi_op_id->noo_completed, NA_FALSE);
     hg_atomic_set32(&na_ofi_op_id->noo_canceled, NA_FALSE);
-    /* Take one refcount to be released in na_ofi_complete->na_ofi_release */
-    hg_atomic_set32(&na_ofi_op_id->noo_refcount, 1);
 
     /* Allocate addr */
     na_ofi_addr = na_ofi_addr_alloc();


### PR DESCRIPTION
na_ofi_addr_lookup() always sets refcount of na_ofi_op_id to 1,
this is incorrect if this ID is passed in by caller.

This patch removes the assignment because na_ofi_op_create() has
already set it to 1 for the case of creation.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>