### PR TITLE
NA OFI: complete canceled RECV ops immediately

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -4789,7 +4789,7 @@ na_ofi_cancel(na_class_t *na_class, na_context_t *context,
             NA_LOG_ERROR("fi_cancel unexpected recv failed, rc: %d(%s).",
                          rc, fi_strerror((int) -rc));
             ret = NA_CANCEL_ERROR;
-            goto out;
+//            goto out;
         }
 
         tmp = first = na_ofi_msg_unexpected_op_pop(context);
@@ -4821,7 +4821,7 @@ na_ofi_cancel(na_class_t *na_class, na_context_t *context,
             NA_LOG_ERROR("fi_cancel expected recv failed, rc: %d(%s).",
                          rc, fi_strerror((int) -rc));
             ret = NA_CANCEL_ERROR;
-            goto out;
+//            goto out;
         }
 
         ret = na_ofi_complete(na_ofi_op_id, NA_CANCELED);


### PR DESCRIPTION
complete canceled RECV ops immediately so that  HG_Context_destroy() can
succeed.

Right now we get errors during HG_Context_destroy()
= = = = = = =
    09/03-23:47:22.31 CaRT[26606/26606] hg   ERR  # NA -- Error -- mercury/src/na/na_ofi.c:4790
     na_ofi_cancel(): fi_cancel unexpected recv failed, rc: -2(No such file or directory).
    09/03-23:47:22.31 CaRT[26606/26606] hg   ERR  # HG -- Error -- mercury/src/mercury_core.c:991
     hg_core_pending_list_cancel(): Could not cancel handle
    09/03-23:47:22.31 CaRT[26606/26606] hg   ERR  # HG -- Error -- mercury/src/mercury_core.c:3836
     HG_Core_context_destroy(): Cannot cancel list of pending entries
    09/03-23:47:22.31 CaRT[26606/26606] hg   ERR  # HG -- Error -- mercury/src/mercury.c:1230
     HG_Context_destroy(): Could not destroy HG core context

= = = = = = = =

Signed-off-by: Yulu Jia <yulu.jia@intel.com>