### PR TITLE
ignore na_ofi_op_id_valid cases

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -2803,16 +2803,13 @@ na_ofi_cq_process_event(na_class_t *na_class, na_context_t *context,
 
     if (!na_ofi_op_id_valid(na_ofi_op_id)) {
         NA_LOG_ERROR("Bad na_ofi_op_id, ignoring event.");
-        ret = NA_PROTOCOL_ERROR;
         goto out;
     }
     if (hg_atomic_get32(&na_ofi_op_id->noo_canceled)) {
-        ret = NA_CANCELED;
         goto complete;
     }
     if (hg_atomic_get32(&na_ofi_op_id->noo_completed)) {
         NA_LOG_ERROR("Ignoring CQ event as the op is completed.");
-        ret = NA_PROTOCOL_ERROR;
         goto out;
     }
 


### PR DESCRIPTION
Ever got such err msg over verbs provider:
09/20-07:13:47.66 wolf-118 DAOS[32101/32126] hg ERR # NA -- Error --
/home/mjean/daos/_build.external/mercury/src/na/na_ofi.c:2627
09/20-07:13:47.66 wolf-118 DAOS[32101/32126] hg ERR # NA -- Error --
/home/mjean/daos/_build.external/mercury/src/na/na_ofi.c:2797
09/20-07:13:47.66 wolf-118 DAOS[32101/32126] hg ERR # NA -- Error --
/home/mjean/daos/_build.external/mercury/src/na/na_ofi.c:4784
09/20-07:13:47.66 wolf-118 DAOS[32101/32126] hg ERR # HG -- Error --
/home/mjean/daos/_build.external/mercury/src/mercury_core.c:2974

It possibly due to get duplicated/invalid completion event from ofi,
can ignore it rather than return error.