### PR TITLE
NA OFI: set op_id to NULL after free

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1838,9 +1838,13 @@ hg_core_alloc_na(struct hg_core_private_handle *hg_core_handle,
     /* Create NA operation IDs */
     hg_core_handle->na_send_op_id = NA_Op_create(hg_core_handle->na_class);
     hg_core_handle->na_recv_op_id = NA_Op_create(hg_core_handle->na_class);
-    if (hg_core_handle->na_recv_op_id || hg_core_handle->na_send_op_id) {
-        if ((hg_core_handle->na_recv_op_id == NA_OP_ID_NULL)
-            || (hg_core_handle->na_send_op_id == NA_OP_ID_NULL)) {
+    hg_core_handle->na_ack_op_id = NA_Op_create(hg_core_handle->na_class);
+    if (hg_core_handle->na_recv_op_id ||
+        hg_core_handle->na_send_op_id ||
+        hg_core_handle->na_ack_op_id ) {
+        if ((hg_core_handle->na_recv_op_id == NA_OP_ID_NULL) ||
+            (hg_core_handle->na_send_op_id == NA_OP_ID_NULL) ||
+            (hg_core_handle->na_ack_op_id == NA_OP_ID_NULL)) {
             HG_LOG_ERROR("NULL operation ID");
             ret = HG_NOMEM_ERROR;
             goto done;
@@ -1872,6 +1876,9 @@ hg_core_free_na(struct hg_core_private_handle *hg_core_handle)
     if (na_ret != NA_SUCCESS)
         HG_LOG_ERROR("Could not destroy NA op ID");
     na_ret = NA_Op_destroy(hg_core_handle->na_class, hg_core_handle->na_recv_op_id);
+    if (na_ret != NA_SUCCESS)
+        HG_LOG_ERROR("Could not destroy NA op ID");
+    na_ret = NA_Op_destroy(hg_core_handle->na_class, hg_core_handle->na_ack_op_id);
     if (na_ret != NA_SUCCESS)
         HG_LOG_ERROR("Could not destroy NA op ID");
 

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1874,9 +1874,6 @@ hg_core_free_na(struct hg_core_private_handle *hg_core_handle)
     na_ret = NA_Op_destroy(hg_core_handle->na_class, hg_core_handle->na_recv_op_id);
     if (na_ret != NA_SUCCESS)
         HG_LOG_ERROR("Could not destroy NA op ID");
-    na_ret = NA_Op_destroy(hg_core_handle->na_class, hg_core_handle->na_ack_op_id);
-    if (na_ret != NA_SUCCESS)
-        HG_LOG_ERROR("Could not destroy NA op ID");
 
     /* Free buffers */
     na_ret = NA_Msg_buf_free(hg_core_handle->na_class,

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1874,6 +1874,9 @@ hg_core_free_na(struct hg_core_private_handle *hg_core_handle)
     na_ret = NA_Op_destroy(hg_core_handle->na_class, hg_core_handle->na_recv_op_id);
     if (na_ret != NA_SUCCESS)
         HG_LOG_ERROR("Could not destroy NA op ID");
+    na_ret = NA_Op_destroy(hg_core_handle->na_class, hg_core_handle->na_ack_op_id);
+    if (na_ret != NA_SUCCESS)
+        HG_LOG_ERROR("Could not destroy NA op ID");
 
     /* Free buffers */
     na_ret = NA_Msg_buf_free(hg_core_handle->na_class,

--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -662,7 +662,7 @@ na_ofi_op_id_addref(struct na_ofi_op_id *na_ofi_op_id);
 /**
  * Decrement refcount on OP ID.
  */
-static NA_INLINE void
+static NA_INLINE na_bool_t
 na_ofi_op_id_decref(struct na_ofi_op_id *na_ofi_op_id);
 
 /**
@@ -2608,7 +2608,7 @@ na_ofi_op_id_addref(struct na_ofi_op_id *na_ofi_op_id)
 }
 
 /*---------------------------------------------------------------------------*/
-static NA_INLINE void
+static NA_INLINE na_bool_t
 na_ofi_op_id_decref(struct na_ofi_op_id *na_ofi_op_id)
 {
     if (na_ofi_op_id == NULL)
@@ -4045,7 +4045,8 @@ out:
     if (ret != NA_SUCCESS) {
         na_ofi_addr_decref(na_ofi_addr);
         if (na_ofi_op_id != NULL)
-            na_ofi_op_id_decref(na_ofi_op_id);
+            if (na_ofi_op_id_decref(na_ofi_op_id))
+                *op_id = NA_OP_ID_NULL;
     }
     return ret;
 }
@@ -4112,7 +4113,8 @@ na_ofi_msg_recv_unexpected(na_class_t *na_class, na_context_t *context,
 
 out:
     if (ret != NA_SUCCESS && na_ofi_op_id != NULL)
-        na_ofi_op_id_decref(na_ofi_op_id);
+        if (na_ofi_op_id_decref(na_ofi_op_id))
+            *op_id = NA_OP_ID_NULL;
     return ret;
 }
 
@@ -4180,7 +4182,8 @@ out:
     if (ret != NA_SUCCESS) {
         na_ofi_addr_decref(na_ofi_addr);
         if (na_ofi_op_id != NULL)
-            na_ofi_op_id_decref(na_ofi_op_id);
+            if (na_ofi_op_id_decref(na_ofi_op_id))
+                *op_id = NA_OP_ID_NULL;
     }
     return ret;
 }
@@ -4253,7 +4256,8 @@ out:
     if (ret != NA_SUCCESS) {
         na_ofi_addr_decref(na_ofi_addr);
         if (na_ofi_op_id != NULL)
-            na_ofi_op_id_decref(na_ofi_op_id);
+            if (na_ofi_op_id_decref(na_ofi_op_id))
+                *op_id = NA_OP_ID_NULL;
     }
     return ret;
 }
@@ -4529,7 +4533,8 @@ out:
     if (ret != NA_SUCCESS) {
         na_ofi_addr_decref(na_ofi_addr);
         if (na_ofi_op_id != NULL)
-            na_ofi_op_id_decref(na_ofi_op_id);
+            if (na_ofi_op_id_decref(na_ofi_op_id))
+                *op_id = NA_OP_ID_NULL;
     }
     return ret;
 }
@@ -4622,7 +4627,8 @@ out:
     if (ret != NA_SUCCESS) {
         na_ofi_addr_decref(na_ofi_addr);
         if (na_ofi_op_id != NULL)
-            na_ofi_op_id_decref(na_ofi_op_id);
+            if (na_ofi_op_id_decref(na_ofi_op_id))
+                *op_id = NA_OP_ID_NULL;
     }
     return ret;
 }

--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -2612,20 +2612,20 @@ static NA_INLINE na_bool_t
 na_ofi_op_id_decref(struct na_ofi_op_id *na_ofi_op_id)
 {
     if (na_ofi_op_id == NULL)
-        return;
+        return NA_FALSE;
 
     assert(hg_atomic_get32(&na_ofi_op_id->noo_refcount) > 0);
 
     /* If there are more references, return */
     if (hg_atomic_decr32(&na_ofi_op_id->noo_refcount))
-        return;
+        return NA_FALSE;
 
     /* No more references, cleanup */
     na_ofi_op_id->noo_magic_1 = 0;
     na_ofi_op_id->noo_magic_2 = 0;
     free(na_ofi_op_id);
 
-    return;
+    return NA_TRUE;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
 - if hg_core_handle->na_recv_op_id
      hg_core_handle->na_send_op_id
      hg_core_handle->na_ack_op_id
   are freed, set them to NULL to avoid potential dangling pointers.

- destroy hg_core_handle->na_ack_op_id in hg_core_free_na()

Signed-off-by: Yulu Jia <yulu.jia@intel.com>