### PR TITLE
NA RECV: force hg_core_handle->ret to HG_CANCELED

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -3542,6 +3542,9 @@ hg_core_cancel(struct hg_core_private_handle *hg_core_handle)
             ret = HG_NA_ERROR;
             goto done;
         }
+
+        /* mark handle as canceled */
+        hg_core_handle->ret = HG_CANCELED;
     }
 
     if (hg_core_handle->na_send_op_id != NA_OP_ID_NULL) {


### PR DESCRIPTION
for na recv operatoins, always set hg_core_handle->ret to HG_CANCELED
when HG_Cancel() didn't return error.

Signed-off-by: Yulu Jia <yulu.jia@intel.com>