### PR TITLE
NA OFI: refactor internal handling of addresses

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -1670,6 +1670,24 @@ done:
 
 /*---------------------------------------------------------------------------*/
 hg_return_t
+HG_Addr_set_remove(hg_class_t *hg_class, hg_addr_t addr)
+{
+    hg_return_t ret = HG_SUCCESS;
+
+    if (!hg_class) {
+        HG_LOG_ERROR("NULL HG class");
+        ret = HG_INVALID_PARAM;
+        goto done;
+    }
+
+    ret = HG_Core_addr_set_remove(hg_class->core_class, (hg_core_addr_t) addr);
+
+done:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+hg_return_t
 HG_Addr_self(hg_class_t *hg_class, hg_addr_t *addr)
 {
     hg_return_t ret = HG_SUCCESS;

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -589,7 +589,7 @@ HG_Addr_lookup(
         );
 
 /**
- * Free the addr from the list of peers.
+ * Free the addr.
  *
  * \param hg_class [IN]         pointer to HG class
  * \param addr [IN]             abstract address
@@ -598,6 +598,23 @@ HG_Addr_lookup(
  */
 HG_EXPORT hg_return_t
 HG_Addr_free(
+        hg_class_t *hg_class,
+        hg_addr_t   addr
+        );
+
+/**
+ * Hint that the address is no longer valid. This may happen if the peer is
+ * no longer responding. This can be used to force removal of the
+ * peer address from the list of the peers, before freeing it and reclaim
+ * resources.
+ *
+ * \param hg_class [IN]         pointer to HG class
+ * \param addr [IN]             abstract address
+ *
+ * \return HG_SUCCESS or corresponding HG error code
+ */
+HG_EXPORT hg_return_t
+HG_Addr_set_remove(
         hg_class_t *hg_class,
         hg_addr_t   addr
         );

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -4372,6 +4372,33 @@ done:
 
 /*---------------------------------------------------------------------------*/
 hg_return_t
+HG_Core_addr_set_remove(hg_core_class_t *hg_core_class, hg_core_addr_t addr)
+{
+    struct hg_core_private_addr *hg_core_addr =
+        (struct hg_core_private_addr *) addr;
+    hg_return_t ret = HG_SUCCESS;
+    na_return_t na_ret;
+
+    if (!hg_core_class) {
+        HG_LOG_ERROR("NULL HG core class");
+        ret = HG_INVALID_PARAM;
+        goto done;
+    }
+
+    na_ret = NA_Addr_set_remove(hg_core_addr->core_addr.na_class,
+        hg_core_addr->core_addr.na_addr);
+    if (na_ret != NA_SUCCESS) {
+        HG_LOG_ERROR("Could not set address to be removed");
+        ret = HG_NA_ERROR;
+        goto done;
+    }
+
+done:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+hg_return_t
 HG_Core_addr_self(hg_core_class_t *hg_core_class, hg_core_addr_t *addr)
 {
     hg_return_t ret = HG_SUCCESS;

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -580,6 +580,23 @@ HG_Core_addr_free(
         );
 
 /**
+ * Hint that the address is no longer valid. This may happen if the peer is
+ * no longer responding. This can be used to force removal of the
+ * peer address from the list of the peers, before freeing it and reclaim
+ * resources.
+ *
+ * \param hg_core_class [IN]    pointer to HG core class
+ * \param addr [IN]             abstract address
+ *
+ * \return HG_SUCCESS or corresponding HG error code
+ */
+HG_EXPORT hg_return_t
+HG_Core_addr_set_remove(
+        hg_core_class_t *hg_core_class,
+        hg_core_addr_t addr
+        );
+
+/**
  * Set the underlying NA address to a HG address.
  *
  * \param core_addr [IN]        abstract address that not set NA address before

--- a/src/na/na.c
+++ b/src/na/na.c
@@ -681,6 +681,27 @@ done:
 
 /*---------------------------------------------------------------------------*/
 na_return_t
+NA_Addr_set_remove(na_class_t *na_class, na_addr_t addr)
+{
+    na_return_t ret = NA_SUCCESS;
+
+    NA_CHECK_ERROR(na_class == NULL, done, ret, NA_INVALID_PARAM,
+        "NULL NA class");
+    if (addr == NA_ADDR_NULL)
+        /* Nothing to do */
+        goto done;
+
+    NA_CHECK_ERROR(na_class->ops == NULL, done, ret, NA_PROTOCOL_ERROR,
+        "NULL NA class ops");
+    if (na_class->ops->addr_set_remove)
+        ret = na_class->ops->addr_set_remove(na_class, addr);
+
+done:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
 NA_Addr_to_string(na_class_t *na_class, char *buf, na_size_t *buf_size,
     na_addr_t addr)
 {

--- a/src/na/na.h
+++ b/src/na/na.h
@@ -264,6 +264,23 @@ NA_Addr_free(
         );
 
 /**
+ * Hint that the address is no longer valid. This may happen if the peer is
+ * no longer responding. This can be used to force removal of the
+ * peer address from the list of the peers, before freeing it and reclaim
+ * resources.
+ *
+ * \param na_class [IN/OUT]     pointer to NA class
+ * \param addr [IN]             abstract address
+ *
+ * \return NA_SUCCESS or corresponding NA error code
+ */
+NA_EXPORT na_return_t
+NA_Addr_set_remove(
+        na_class_t *na_class,
+        na_addr_t   addr
+        );
+
+/**
  * Access self address.
  *
  * \param na_class [IN/OUT]     pointer to NA class
@@ -1146,6 +1163,11 @@ struct na_class_ops {
             );
     na_return_t
     (*addr_free)(
+            na_class_t *na_class,
+            na_addr_t   addr
+            );
+    na_return_t
+    (*addr_set_remove)(
             na_class_t *na_class,
             na_addr_t   addr
             );

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -515,6 +515,7 @@ NA_PLUGIN_OPS(bmi) = {
         na_bmi_addr_lookup,                   /* addr_lookup */
         NULL,                                 /* addr_lookup2 */
         na_bmi_addr_free,                     /* addr_free */
+        NULL,                                 /* addr_set_remove */
         na_bmi_addr_self,                     /* addr_self */
         na_bmi_addr_dup,                      /* addr_dup */
         na_bmi_addr_is_self,                  /* addr_is_self */

--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -373,6 +373,7 @@ NA_PLUGIN_OPS(cci) = {
     na_cci_addr_lookup,                     /* addr_lookup */
     NULL,                                   /* addr_lookup2 */
     na_cci_addr_free,                       /* addr_free */
+    NULL,                                   /* addr_set_remove */
     na_cci_addr_self,                       /* addr_self */
     na_cci_addr_dup,                        /* addr_dup */
     na_cci_addr_is_self,                    /* addr_is_self */

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -544,6 +544,7 @@ NA_PLUGIN_OPS(mpi) = {
         na_mpi_addr_lookup,                   /* addr_lookup */
         NULL,                                 /* addr_lookup2 */
         na_mpi_addr_free,                     /* addr_free */
+        NULL,                                 /* addr_set_remove */
         na_mpi_addr_self,                     /* addr_self */
         NULL,                                 /* addr_dup */
         na_mpi_addr_is_self,                  /* addr_is_self */

--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -130,7 +130,7 @@
         "",                                                             \
         FI_SOCKADDR_IN,                                                 \
         FI_PROGRESS_AUTO,                                               \
-        FI_DIRECTED_RECV,                                               \
+        (FI_SOURCE | FI_DIRECTED_RECV),                                 \
         (NA_OFI_VERIFY_PROV_DOM | NA_OFI_WAIT_FD)                       \
     )                                                                   \
     X(NA_OFI_PROV_TCP,                                                  \
@@ -138,7 +138,7 @@
         "tcp",                                                          \
         FI_SOCKADDR_IN,                                                 \
         FI_PROGRESS_MANUAL,                                             \
-        FI_DIRECTED_RECV,                                               \
+        (FI_SOURCE | FI_DIRECTED_RECV),                                 \
         (NA_OFI_WAIT_FD | NA_OFI_NO_SEP | NA_OFI_SKIP_SIGNAL)           \
     )                                                                   \
     X(NA_OFI_PROV_PSM2,                                                 \
@@ -154,7 +154,7 @@
         "verbs",                                                        \
         FI_SOCKADDR_IN,                                                 \
         FI_PROGRESS_MANUAL,                                             \
-        (FI_DIRECTED_RECV),                                             \
+        (FI_SOURCE | FI_DIRECTED_RECV),                                 \
         (NA_OFI_VERIFY_PROV_DOM | NA_OFI_WAIT_FD | NA_OFI_NO_SEP | NA_OFI_SKIP_SIGNAL)   \
     )                                                                   \
     X(NA_OFI_PROV_GNI,                                                  \

--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -902,6 +902,7 @@ NA_PLUGIN_OPS(sm) = {
     na_sm_addr_lookup,                      /* addr_lookup */
     NULL,                                   /* addr_lookup2 */
     na_sm_addr_free,                        /* addr_free */
+    NULL,                                   /* addr_set_remove */
     na_sm_addr_self,                        /* addr_self */
     na_sm_addr_dup,                         /* addr_dup */
     na_sm_addr_is_self,                     /* addr_is_self */


### PR DESCRIPTION
Prevent some extra allocations
Allow for unexpected and deserialized addresses to be converted to strings