### PR TITLE
NA OFI: allow for passing explicit domain name (fixes #297)

### DIFF
--- a/Testing/na/na_test.h
+++ b/Testing/na/na_test.h
@@ -27,6 +27,7 @@ struct na_test_info {
     na_class_t *na_class;       /* NA class */
     char *target_name;          /* Target name */
     char *comm;                 /* Comm/Plugin name */
+    char *domain;               /* Domain name */
     char *protocol;             /* Protocol name */
     char *hostname;             /* Hostname */
     na_bool_t listen;           /* Listen */

--- a/Testing/na/na_test_getopt.c
+++ b/Testing/na/na_test_getopt.c
@@ -17,10 +17,11 @@
 
 int na_test_opt_ind_g = 1; /* token pointer */
 const char *na_test_opt_arg_g = NULL; /* flag argument (or value) */
-const char *na_test_short_opt_g = "hc:p:H:LsSak:l:t:bmC:V";
+const char *na_test_short_opt_g = "hc:d:p:H:LsSak:l:t:bmC:V";
 const struct na_test_opt na_test_opt_g[] = {
     { "help", no_arg, 'h'},
     { "comm", require_arg, 'c' },
+    { "domain", require_arg, 'd' },
     { "protocol", require_arg, 'p' },
     { "hostname", require_arg, 'H' },
     { "listen", no_arg, 'L' },


### PR DESCRIPTION
Users can now pass: ofi+protocol://domain/iface:port
(e.g., ofi+verbs://mlx5_0/ib0:12345)

Are also valid:
  - ofi+protocol://domain/hostname:port
  - ofi+protocol://domain
  - ofi+protocol://iface
  - ofi+protocol://hostname
  - ofi+protocol://domain/iface
  - ofi+protocol://domain/hostname
  - ofi+protocol://iface:port
  - ofi+protocol://hostname:port

Update NA tests to use domain name