### PR TITLE
NA OFI: ignore fi_cancel's failure

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -4413,9 +4413,9 @@ na_ofi_cancel(na_class_t *na_class, na_context_t *context,
 
         rc = fi_cancel(&NA_OFI_CONTEXT(context)->fi_rx->fid,
             &na_ofi_op_id->fi_ctx);
-        NA_CHECK_ERROR(rc != 0, out, ret, NA_CANCEL_ERROR,
-            "fi_cancel() unexpected recv failed, rc: %d(%s)",
-            rc, fi_strerror((int) -rc));
+        if (rc != 0)
+            NA_LOG_WARNING("fi_cancel() unexpected recv failed, rc: %d(%s)",
+                           rc, fi_strerror((int) -rc));
 
         tmp = first = na_ofi_msg_unexpected_op_pop(context);
         do {
@@ -4436,9 +4436,9 @@ na_ofi_cancel(na_class_t *na_class, na_context_t *context,
     case NA_CB_RECV_EXPECTED:
         rc = fi_cancel(&NA_OFI_CONTEXT(context)->fi_rx->fid,
             &na_ofi_op_id->fi_ctx);
-        NA_CHECK_ERROR(rc != 0, out, ret, NA_CANCEL_ERROR,
-            "fi_cancel() expected recv failed, rc: %d(%s)",
-            rc, fi_strerror((int) -rc));
+        if (rc != 0)
+            NA_LOG_WARNING("fi_cancel() expected recv failed, rc: %d(%s)",
+                           rc, fi_strerror((int) -rc));
 
         ret = na_ofi_complete(na_ofi_op_id, NA_CANCELED);
         break;
@@ -4449,10 +4449,9 @@ na_ofi_cancel(na_class_t *na_class, na_context_t *context,
         /* May or may not be canceled in that case */
         rc = fi_cancel(&NA_OFI_CONTEXT(context)->fi_tx->fid,
             &na_ofi_op_id->fi_ctx);
-        if (rc != 0) {
+        if (rc != 0)
             NA_LOG_WARNING("fi_cancel() failed, rc: %d(%s)",
-                         rc, fi_strerror((int) -rc));
-        }
+                           rc, fi_strerror((int) -rc));
         /* fi_cancel() is not guaranteed to return proper return code for now */
 //        if (rc == 0) {
             /* Complete only if successfully canceled */


### PR DESCRIPTION
Ignore fi_cancel's failure (just add a warning log msg).
We observed a DAOS test failure that:
1) RPC timedout for some reason,
2) DAOS calls HG_Cancel() but it fails, then DAOS complete that RPC
3) The RPC's completion callback (crt_hg_req_send_cb) being triggered
   again by mercury, this cause the error that one RPC's completion
   callback being called twice.

This patch fixes it by ignoring fi_cancel()'s failure, so won't return
error by HG_Cancel() by step 2), because at mercury level it return
error for HG_Cancel() and trigger the same RPC's completion callback
later should be an issue.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>