### PR TITLE
HG: add HG_OTHER_ERROR return code back

### DIFF
--- a/src/mercury_core_types.h
+++ b/src/mercury_core_types.h
@@ -54,6 +54,7 @@ struct hg_init_info {
     X(HG_CANCELED)          /*!< operation canceled */                      \
     X(HG_CHECKSUM_ERROR)    /*!< checksum error */                          \
     X(HG_NA_ERROR)          /*!< generic NA error */                        \
+    X(HG_OTHER_ERROR)       /*!< generic HG error */                        \
     X(HG_RETURN_MAX)
 
 #define X(a) a,


### PR DESCRIPTION
May be used by RPC callback to return error codes back to client