### PR TITLE
Rework of HG polling mechanism

### DIFF
--- a/Testing/na/CMakeLists.txt
+++ b/Testing/na/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 build_na_test(server)
 #build_na_test(cancel_client)
 build_na_test(cancel_server)
-#build_na_test(lat_client)
+build_na_test(lat_client)
 build_na_test(lat_server)
 
 #------------------------------------------------------------------------------

--- a/Testing/util/test_poll.c
+++ b/Testing/util/test_poll.c
@@ -1,102 +1,144 @@
-#include "mercury_poll.h"
 #include "mercury_event.h"
+#include "mercury_poll.h"
 
 #include "mercury_test_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
-struct hg_test_poll_cb_args {
-    int event_fd;
-};
-
-static int
-poll_cb(void *arg, int error, struct hg_poll_event *event)
-{
-    struct hg_test_poll_cb_args *poll_cb_args =
-        (struct hg_test_poll_cb_args *) arg;
-    (void) error;
-
-    hg_event_get(poll_cb_args->event_fd, &event->progressed);
-
-    return HG_UTIL_SUCCESS;
-}
-
 int
 main(void)
 {
-    struct hg_test_poll_cb_args poll_cb_args;
     hg_poll_set_t *poll_set;
-    struct hg_poll_event events[1];
+    struct hg_poll_event events[2];
     unsigned int nevents = 0;
-    int event_fd, ret = EXIT_SUCCESS;
+    hg_util_bool_t signaled = HG_UTIL_FALSE;
+    int event_fd1, event_fd2, ret = EXIT_SUCCESS;
 
     poll_set = hg_poll_create();
-    event_fd = hg_event_create();
-
-    poll_cb_args.event_fd = event_fd;
+    event_fd1 = hg_event_create();
+    event_fd2 = hg_event_create();
 
     /* Add event descriptor */
-    hg_poll_add(poll_set, event_fd, HG_POLLIN, poll_cb, &poll_cb_args);
+    events[0].events = HG_POLLIN;
+    events[1].events = HG_POLLIN;
+
+    hg_poll_add(poll_set, event_fd1, &events[0]);
+    hg_poll_add(poll_set, event_fd2, &events[1]);
 
     /* Set event */
-    hg_event_set(event_fd);
+    hg_event_set(event_fd1);
 
     /* Wait with timeout 0 */
     hg_poll_wait(poll_set, 0, 1, events, &nevents);
-    if ((nevents != 1) || !events[0].progressed) {
+    if (nevents != 1) {
         /* We expect success */
         fprintf(stderr, "Error: should have progressed\n");
         ret = EXIT_FAILURE;
         goto done;
     }
-
-    /* Reset progressed */
-    nevents = 0;
-    events[0].progressed = HG_UTIL_FALSE;
-
-    /* Wait with timeout 0 */
-    hg_poll_wait(poll_set, 0, 1, events, &nevents);
-    if ((nevents != 1) || events[0].progressed) {
-        /* We do not expect success */
-        fprintf(stderr, "Error: should not have progressed\n");
+    hg_event_get(event_fd1, &signaled);
+    if (!signaled) {
+        /* We expect success */
+        fprintf(stderr, "Error: should have been signaled\n");
         ret = EXIT_FAILURE;
         goto done;
     }
 
     /* Reset progressed */
     nevents = 0;
-    events[0].progressed = HG_UTIL_FALSE;
+
+    /* Wait with timeout 0 */
+    hg_poll_wait(poll_set, 0, 1, events, &nevents);
+    if (nevents) {
+        /* We do not expect success */
+        fprintf(stderr, "Error: should not have progressed (timeout 0)\n");
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+
+    /* Reset progressed */
+    nevents = 0;
 
     /* Wait with timeout */
     hg_poll_wait(poll_set, 100, 1, events, &nevents);
-    if (nevents || events[0].progressed) {
+    if (nevents) {
         /* We do not expect success */
-        fprintf(stderr, "Error: should not have progressed\n");
+        fprintf(stderr, "Error: should not have progressed (timeout 100)\n");
         ret = EXIT_FAILURE;
         goto done;
     }
 
     /* Set event */
-    hg_event_set(event_fd);
+    hg_event_set(event_fd1);
 
     /* Reset progressed */
     nevents = 0;
-    events[0].progressed = HG_UTIL_FALSE;
 
     /* Wait with timeout */
     hg_poll_wait(poll_set, 1000, 1, events, &nevents);
-    if (!nevents || !events[0].progressed) {
+    if (!nevents) {
         /* We expect success */
         fprintf(stderr, "Error: did not progress correctly\n");
         ret = EXIT_FAILURE;
         goto done;
     }
+    hg_event_get(event_fd1, &signaled);
+    if (!signaled) {
+        /* We expect success */
+        fprintf(stderr, "Error: should have been signaled\n");
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+
+    /* Set event */
+    hg_event_set(event_fd1);
+    hg_event_set(event_fd2);
+
+    /* Reset progressed */
+    nevents = 0;
+
+    /* Wait with timeout */
+    hg_poll_wait(poll_set, 1000, 1, events, &nevents);
+    if (nevents != 1) {
+        /* We do not expect success */
+        fprintf(stderr, "Error: should not have progressed first time\n");
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+    hg_event_get(event_fd1, &signaled);
+    if (!signaled) {
+        /* We expect success */
+        fprintf(stderr, "Error: should have been signaled\n");
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+
+    /* Reset progressed */
+    nevents = 0;
+
+    /* Wait with timeout */
+    hg_poll_wait(poll_set, 1000, 2, events, &nevents);
+    if (nevents != 1) {
+        /* We expect success */
+        fprintf(stderr, "Error: did not progress second time\n");
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+    hg_event_get(event_fd2, &signaled);
+    if (!signaled) {
+        /* We expect success */
+        fprintf(stderr, "Error: should have been signaled\n");
+        ret = EXIT_FAILURE;
+        goto done;
+    }
 
 done:
-    hg_poll_remove(poll_set, event_fd);
+    hg_poll_remove(poll_set, event_fd1);
+    hg_poll_remove(poll_set, event_fd2);
     hg_poll_destroy(poll_set);
-    hg_event_destroy(event_fd);
+    hg_event_destroy(event_fd1);
+    hg_event_destroy(event_fd2);
 
     return ret;
 }

--- a/src/util/mercury_poll.c
+++ b/src/util/mercury_poll.c
@@ -9,10 +9,8 @@
  */
 
 #include "mercury_poll.h"
-#include "mercury_atomic.h"
 #include "mercury_event.h"
-#include "mercury_list.h"
-#include "mercury_thread_spin.h"
+#include "mercury_thread_mutex.h"
 #include "mercury_util_error.h"
 
 #include <stdlib.h>
@@ -37,7 +35,8 @@
 /* Local Macros */
 /****************/
 
-#define HG_POLL_MAX_EVENTS 1024
+#define HG_POLL_INIT_NEVENTS 32
+#define HG_POLL_MAX_EVENTS   4096
 
 #ifndef MIN
 #    define MIN(a, b) (((a) < (b)) ? (a) : (b))
@@ -47,26 +46,19 @@
 /* Local Type and Struct Definition */
 /************************************/
 
-struct hg_poll_data {
-#if defined(HG_UTIL_HAS_SYSEPOLL_H)
-    int fd;
-#elif defined(HG_UTIL_HAS_SYSEVENT_H)
-    struct kevent kev;
-#else
-    struct pollfd pollfd;
-#endif
-    hg_poll_cb_t poll_cb;
-    void *poll_arg;
-    HG_LIST_ENTRY(hg_poll_data) entry;
-};
-
 struct hg_poll_set {
+    hg_thread_mutex_t lock;
+#if defined(HG_UTIL_HAS_SYSEPOLL_H)
+    struct epoll_event *events;
+#elif defined(HG_UTIL_HAS_SYSEVENT_H)
+    struct kevent *events;
+#else
+    struct pollfd *events;
+    hg_poll_data_t *event_data;
+#endif
+    unsigned int max_events;
+    unsigned int nfds;
     int fd;
-    hg_atomic_int32_t nfds;
-    hg_poll_try_wait_cb_t try_wait_cb;
-    void *try_wait_arg;
-    HG_LIST_HEAD(hg_poll_data) poll_data_list;
-    hg_thread_spin_t poll_data_list_lock;
 };
 
 /********************/
@@ -85,35 +77,46 @@ hg_poll_create(void)
 
     hg_poll_set = malloc(sizeof(struct hg_poll_set));
     HG_UTIL_CHECK_ERROR_NORET(
-        hg_poll_set == NULL, error, "malloc() failed (%s)");
+        hg_poll_set == NULL, error, "malloc() failed (%s)", strerror(errno));
+
+    hg_thread_mutex_init(&hg_poll_set->lock);
+    hg_poll_set->nfds = 0;
+    hg_poll_set->max_events = HG_POLL_INIT_NEVENTS;
+
+    /* Preallocate events, size will grow as needed */
+    hg_poll_set->events =
+        malloc(sizeof(*hg_poll_set->events) * hg_poll_set->max_events);
+    HG_UTIL_CHECK_ERROR_NORET(
+        !hg_poll_set->events, error, "malloc() failed (%s)", strerror(errno));
+
 #if defined(_WIN32)
     /* TODO */
-#else
-    HG_LIST_INIT(&hg_poll_set->poll_data_list);
-    hg_thread_spin_init(&hg_poll_set->poll_data_list_lock);
-    hg_atomic_init32(&hg_poll_set->nfds, 0);
-    hg_poll_set->try_wait_cb = NULL;
-
-#    if defined(HG_UTIL_HAS_SYSEPOLL_H)
+#elif defined(HG_UTIL_HAS_SYSEPOLL_H)
     hg_poll_set->fd = epoll_create1(0);
     HG_UTIL_CHECK_ERROR_NORET(hg_poll_set->fd == -1, error,
         "epoll_create1() failed (%s)", strerror(errno));
-#    elif defined(HG_UTIL_HAS_SYSEVENT_H)
+#elif defined(HG_UTIL_HAS_SYSEVENT_H)
     hg_poll_set->fd = kqueue();
     HG_UTIL_CHECK_ERROR_NORET(
         hg_poll_set->fd == -1, error, "kqueue() failed (%s)", strerror(errno));
-#    else
+#else
     hg_poll_set->fd = hg_event_create();
     HG_UTIL_CHECK_ERROR_NORET(hg_poll_set->fd == -1, error,
         "hg_event_create() failed (%s)", strerror(errno));
-#    endif
-#endif /* defined(_WIN32) */
+
+    /* Preallocate event_data, size will grow as needed */
+    hg_poll_set->event_data =
+        malloc(sizeof(*hg_poll_set->event_data) * hg_poll_set->max_events);
+    HG_UTIL_CHECK_ERROR_NORET(
+        !hg_poll_set->events, error, "malloc() failed (%s)", strerror(errno));
+#endif
 
     return hg_poll_set;
 
 error:
     if (hg_poll_set) {
-        hg_thread_spin_destroy(&hg_poll_set->poll_data_list_lock);
+        free(hg_poll_set->events);
+        hg_thread_mutex_destroy(&hg_poll_set->lock);
         free(hg_poll_set);
     }
     return NULL;
@@ -129,26 +132,28 @@ hg_poll_destroy(hg_poll_set_t *poll_set)
     if (!poll_set)
         goto done;
 
-#if defined(_WIN32)
-        /* TODO */
-#else
-    HG_UTIL_CHECK_ERROR(hg_atomic_get32(&poll_set->nfds), done, ret,
-        HG_UTIL_FAIL, "Poll set non empty");
+    HG_UTIL_CHECK_ERROR(
+        poll_set->nfds > 0, done, ret, HG_UTIL_FAIL, "Poll set non empty");
 
-#    if defined(HG_UTIL_HAS_SYSEPOLL_H) || defined(HG_UTIL_HAS_SYSEVENT_H)
+#if defined(_WIN32)
+    /* TODO */
+#elif defined(HG_UTIL_HAS_SYSEPOLL_H) || defined(HG_UTIL_HAS_SYSEVENT_H)
     /* Close poll descriptor */
     rc = close(poll_set->fd);
     HG_UTIL_CHECK_ERROR(rc == -1, done, ret, HG_UTIL_FAIL,
         "close() failed (%s)", strerror(errno));
-#    else
+#else
     rc = hg_event_destroy(poll_set->fd);
     HG_UTIL_CHECK_ERROR(rc == HG_UTIL_FAIL, done, ret, HG_UTIL_FAIL,
         "hg_event_destroy() failed (%s)", strerror(errno));
-#    endif
+#endif
 
-    hg_thread_spin_destroy(&poll_set->poll_data_list_lock);
-#endif /* defined(_WIN32) */
-
+    hg_thread_mutex_destroy(&poll_set->lock);
+#if !defined(_WIN32) && !defined(HG_UTIL_HAS_SYSEPOLL_H) &&                    \
+    !defined(HG_UTIL_HAS_SYSEVENT_H)
+    free(poll_set->event_data);
+#endif
+    free(poll_set->events);
     free(poll_set);
 
 done:
@@ -159,208 +164,176 @@ done:
 int
 hg_poll_get_fd(hg_poll_set_t *poll_set)
 {
-    int fd = -1;
+#if defined(_WIN32)
+    /* TODO */
+    return -1;
+#else
+    return poll_set->fd;
+#endif
+}
 
-    HG_UTIL_CHECK_ERROR_NORET(!poll_set, done, "NULL poll set");
+/*---------------------------------------------------------------------------*/
+int
+hg_poll_add(hg_poll_set_t *poll_set, int fd, struct hg_poll_event *event)
+{
+#if defined(_WIN32)
+    /* TODO */
+#elif defined(HG_UTIL_HAS_SYSEPOLL_H)
+    struct epoll_event ev;
+    uint32_t poll_flags = 0;
+    int rc;
+#elif defined(HG_UTIL_HAS_SYSEVENT_H)
+    struct kevent ev;
+    struct timespec timeout = {0, 0};
+    int16_t poll_flags = 0;
+    int rc;
+#else
+    struct pollfd ev;
+    short int poll_flags = 0;
+#endif
+    int ret = HG_UTIL_SUCCESS;
+
+    HG_UTIL_CHECK_ERROR(fd <= STDERR_FILENO, done, ret, HG_UTIL_FAIL,
+        "fd is not valid (%d)", fd);
 
 #if defined(_WIN32)
     /* TODO */
+#elif defined(HG_UTIL_HAS_SYSEPOLL_H)
+    /* Translate flags */
+    if (event->events & HG_POLLIN)
+        poll_flags |= EPOLLIN;
+    if (event->events & HG_POLLOUT)
+        poll_flags |= EPOLLOUT;
+
+    ev.events = poll_flags;
+    ev.data.u64 = (uint64_t) event->data.u64;
+
+    rc = epoll_ctl(poll_set->fd, EPOLL_CTL_ADD, fd, &ev);
+    HG_UTIL_CHECK_ERROR(rc != 0, done, ret, HG_UTIL_FAIL,
+        "epoll_ctl() failed (%s)", strerror(errno));
+#elif defined(HG_UTIL_HAS_SYSEVENT_H)
+    /* Translate flags */
+    if (event->events & HG_POLLIN)
+        poll_flags |= EVFILT_READ;
+    if (event->events & HG_POLLOUT)
+        poll_flags |= EVFILT_WRITE;
+
+    EV_SET(&ev, (uintptr_t) fd, poll_flags, EV_ADD, 0, 0, event->data.ptr);
+
+    rc = kevent(poll_set->fd, &ev, 1, NULL, 0, &timeout);
+    HG_UTIL_CHECK_ERROR(rc == -1, done, ret, HG_UTIL_FAIL,
+        "kevent() failed (%s)", strerror(errno));
 #else
-    fd = poll_set->fd;
+    /* Translate flags */
+    if (event->events & HG_POLLIN)
+        poll_flags |= POLLIN;
+    if (event->events & HG_POLLOUT)
+        poll_flags |= POLLOUT;
+
+    ev.fd = fd;
+    ev.events = poll_flags;
+    ev.revents = 0;
 #endif
 
-done:
-    return fd;
-}
+    hg_thread_mutex_lock(&poll_set->lock);
 
-/*---------------------------------------------------------------------------*/
-int
-hg_poll_set_try_wait(
-    hg_poll_set_t *poll_set, hg_poll_try_wait_cb_t try_wait_cb, void *arg)
-{
-    int ret = HG_UTIL_SUCCESS;
+#if !defined(_WIN32) && !defined(HG_UTIL_HAS_SYSEPOLL_H) &&                    \
+    !defined(HG_UTIL_HAS_SYSEVENT_H)
+    /* Grow array if reached max number */
+    if (poll_set->nfds == poll_set->max_events) {
+        HG_UTIL_CHECK_ERROR(poll_set->max_events * 2 > HG_POLL_MAX_EVENTS,
+            unlock, ret, HG_UTIL_FAIL,
+            "reached max number of events for this poll set (%d)",
+            poll_set->max_events);
 
-    HG_UTIL_CHECK_ERROR(!poll_set, done, ret, HG_UTIL_FAIL, "NULL poll set");
+        poll_set->events = realloc(poll_set->events,
+            sizeof(*poll_set->events) * poll_set->max_events * 2);
+        HG_UTIL_CHECK_ERROR(!poll_set->events, unlock, ret, HG_UTIL_FAIL,
+            "realloc() failed (%s)", strerror(errno));
 
-    poll_set->try_wait_cb = try_wait_cb;
-    poll_set->try_wait_arg = arg;
+        poll_set->event_data = realloc(poll_set->event_data,
+            sizeof(*poll_set->event_data) * poll_set->max_events * 2);
+        HG_UTIL_CHECK_ERROR(!poll_set->event_data, unlock, ret, HG_UTIL_FAIL,
+            "realloc() failed (%s)", strerror(errno));
 
-done:
-    return ret;
-}
-
-/*---------------------------------------------------------------------------*/
-int
-hg_poll_add(hg_poll_set_t *poll_set, int fd, unsigned int flags,
-    hg_poll_cb_t poll_cb, void *poll_arg)
-{
-    struct hg_poll_data *hg_poll_data = NULL;
-    int ret = HG_UTIL_SUCCESS;
-
-    HG_UTIL_CHECK_ERROR(!poll_set, done, ret, HG_UTIL_FAIL, "NULL poll set");
-
-    /* Allocate poll data that can hold user data and callback */
-    hg_poll_data = malloc(sizeof(struct hg_poll_data));
-    HG_UTIL_CHECK_ERROR(
-        !hg_poll_data, done, ret, HG_UTIL_FAIL, "malloc() failed (%s)");
-    memset(hg_poll_data, 0, sizeof(struct hg_poll_data));
-    hg_poll_data->poll_cb = poll_cb;
-    hg_poll_data->poll_arg = poll_arg;
-
-    if (fd > 0) {
-#if defined(_WIN32)
-        /* TODO */
-#elif defined(HG_UTIL_HAS_SYSEPOLL_H)
-        struct epoll_event ev;
-        uint32_t poll_flags;
-        int rc;
-
-        /* Translate flags */
-        switch (flags) {
-            case HG_POLLIN:
-                poll_flags = EPOLLIN;
-                break;
-            case HG_POLLOUT:
-                poll_flags = EPOLLOUT;
-                break;
-            default:
-                HG_UTIL_GOTO_ERROR(error, ret, HG_UTIL_FAIL, "Invalid flag");
-        }
-
-        hg_poll_data->fd = fd;
-        ev.events = poll_flags;
-        ev.data.ptr = hg_poll_data;
-
-        rc = epoll_ctl(poll_set->fd, EPOLL_CTL_ADD, fd, &ev);
-        HG_UTIL_CHECK_ERROR(rc != 0, error, ret, HG_UTIL_FAIL,
-            "epoll_ctl() failed (%s)", strerror(errno));
-#elif defined(HG_UTIL_HAS_SYSEVENT_H)
-        struct timespec timeout = {0, 0};
-        int16_t poll_flags;
-        int rc;
-
-        /* Translate flags */
-        switch (flags) {
-            case HG_POLLIN:
-                poll_flags = EVFILT_READ;
-                break;
-            case HG_POLLOUT:
-                poll_flags = EVFILT_WRITE;
-                break;
-            default:
-                HG_UTIL_GOTO_ERROR(error, ret, HG_UTIL_FAIL, "Invalid flag");
-        }
-
-        EV_SET(&hg_poll_data->kev, (uintptr_t) fd, poll_flags, EV_ADD, 0, 0,
-            hg_poll_data);
-
-        rc = kevent(poll_set->fd, &hg_poll_data->kev, 1, NULL, 0, &timeout);
-        HG_UTIL_CHECK_ERROR(rc == -1, error, ret, HG_UTIL_FAIL,
-            "kevent() failed (%s)", strerror(errno));
-#else
-        short int poll_flags;
-
-        /* Translate flags */
-        switch (flags) {
-            case HG_POLLIN:
-                poll_flags = POLLIN;
-                break;
-            case HG_POLLOUT:
-                poll_flags = POLLOUT;
-                break;
-            default:
-                HG_UTIL_GOTO_ERROR(error, ret, HG_UTIL_FAIL, "Invalid flag");
-        }
-
-        hg_poll_data->pollfd.fd = fd;
-        hg_poll_data->pollfd.events = poll_flags;
-        hg_poll_data->pollfd.revents = 0;
-#endif /* defined(_WIN32) */
+        poll_set->max_events *= 2;
     }
-    hg_atomic_incr32(&poll_set->nfds);
+    poll_set->events[poll_set->nfds] = ev;
+    poll_set->event_data[poll_set->nfds] = event->data;
+#endif
+    poll_set->nfds++;
 
-    hg_thread_spin_lock(&poll_set->poll_data_list_lock);
-    HG_LIST_INSERT_HEAD(&poll_set->poll_data_list, hg_poll_data, entry);
-    hg_thread_spin_unlock(&poll_set->poll_data_list_lock);
+#if !defined(_WIN32) && !defined(HG_UTIL_HAS_SYSEPOLL_H) &&                    \
+    !defined(HG_UTIL_HAS_SYSEVENT_H)
+unlock:
+#endif
+    hg_thread_mutex_unlock(&poll_set->lock);
 
 done:
     return ret;
-
-error:
-    free(hg_poll_data);
-
-    return HG_UTIL_FAIL;
 }
 
 /*---------------------------------------------------------------------------*/
 int
 hg_poll_remove(hg_poll_set_t *poll_set, int fd)
 {
-    struct hg_poll_data *hg_poll_data;
-    hg_util_bool_t found = HG_UTIL_FALSE;
+#if defined(_WIN32)
+    /* TODO */
+#elif defined(HG_UTIL_HAS_SYSEPOLL_H)
+    int rc;
+#elif defined(HG_UTIL_HAS_SYSEVENT_H)
+    struct kevent ev;
+    struct timespec timeout = {0, 0};
+    int rc;
+#else
+    int i, found = -1;
+#endif
     int ret = HG_UTIL_SUCCESS;
 
-    HG_UTIL_CHECK_ERROR(!poll_set, done, ret, HG_UTIL_FAIL, "NULL poll set");
+    HG_UTIL_CHECK_ERROR(fd <= STDERR_FILENO, done, ret, HG_UTIL_FAIL,
+        "fd is not valid (%d)", fd);
 
-    hg_thread_spin_lock(&poll_set->poll_data_list_lock);
-    HG_LIST_FOREACH (hg_poll_data, &poll_set->poll_data_list, entry) {
 #if defined(_WIN32)
-        /* TODO */
+    /* TODO */
 #elif defined(HG_UTIL_HAS_SYSEPOLL_H)
-        if (hg_poll_data->fd == fd) {
-            HG_LIST_REMOVE(hg_poll_data, entry);
-
-            if (fd > 0) {
-                int rc = epoll_ctl(poll_set->fd, EPOLL_CTL_DEL, fd, NULL);
-                HG_UTIL_CHECK_ERROR(rc != 0, error, ret, HG_UTIL_FAIL,
-                    "epoll_ctl() failed (%s)", strerror(errno));
-            }
-            free(hg_poll_data);
-            found = HG_UTIL_TRUE;
-            break;
-        }
+    rc = epoll_ctl(poll_set->fd, EPOLL_CTL_DEL, fd, NULL);
+    HG_UTIL_CHECK_ERROR(rc != 0, done, ret, HG_UTIL_FAIL,
+        "epoll_ctl() failed (%s)", strerror(errno));
+    hg_thread_mutex_lock(&poll_set->lock);
 #elif defined(HG_UTIL_HAS_SYSEVENT_H)
-        /* Events which are attached to file descriptors are automatically
-         * deleted on the last close of the descriptor. */
-        if ((int) hg_poll_data->kev.ident == fd) {
-            HG_LIST_REMOVE(hg_poll_data, entry);
-
-            if (fd > 0) {
-                struct timespec timeout = {0, 0};
-                int rc;
-
-                EV_SET(&hg_poll_data->kev, (uintptr_t) fd, EVFILT_READ,
-                    EV_DELETE, 0, 0, NULL);
-                rc = kevent(
-                    poll_set->fd, &hg_poll_data->kev, 1, NULL, 0, &timeout);
-                HG_UTIL_CHECK_ERROR(rc == -1, error, ret, HG_UTIL_FAIL,
-                    "kevent() failed (%s)", strerror(errno));
-            }
-            free(hg_poll_data);
-            found = HG_UTIL_TRUE;
-            break;
-        }
+    /* Events which are attached to file descriptors are automatically
+     * deleted on the last close of the descriptor. */
+    EV_SET(&ev, (uintptr_t) fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+    rc = kevent(poll_set->fd, &ev, 1, NULL, 0, &timeout);
+    HG_UTIL_CHECK_ERROR(rc == -1, done, ret, HG_UTIL_FAIL,
+        "kevent() failed (%s)", strerror(errno));
+    hg_thread_mutex_lock(&poll_set->lock);
 #else
-        if (hg_poll_data->pollfd.fd == fd) {
-            HG_LIST_REMOVE(hg_poll_data, entry);
-            free(hg_poll_data);
-            found = HG_UTIL_TRUE;
+    hg_thread_mutex_lock(&poll_set->lock);
+    for (i = 0; i < (int) poll_set->nfds; i++) {
+        if (poll_set->events[i].fd == fd) {
+            found = i;
             break;
         }
-#endif
     }
-    hg_thread_spin_unlock(&poll_set->poll_data_list_lock);
-
     HG_UTIL_CHECK_ERROR(
-        !found, done, ret, HG_UTIL_FAIL, "Could not find fd in poll_set");
-    hg_atomic_decr32(&poll_set->nfds);
+        found < 0, error, ret, HG_UTIL_FAIL, "Could not find fd in poll_set");
+
+    for (i = found; i < (int) poll_set->nfds - 1; i++) {
+        poll_set->events[i] = poll_set->events[i + 1];
+        poll_set->event_data[i] = poll_set->event_data[i + 1];
+    }
+#endif
+    poll_set->nfds--;
+    hg_thread_mutex_unlock(&poll_set->lock);
 
 done:
     return ret;
 
-#if defined(HG_UTIL_HAS_SYSEPOLL_H) || defined(HG_UTIL_HAS_SYSEVENT_H)
+#if !defined(_WIN32) && !defined(HG_UTIL_HAS_SYSEPOLL_H) &&                    \
+    !defined(HG_UTIL_HAS_SYSEVENT_H)
 error:
-    hg_thread_spin_unlock(&poll_set->poll_data_list_lock);
+    hg_thread_mutex_unlock(&poll_set->lock);
 
     return ret;
 #endif
@@ -372,160 +345,151 @@ hg_poll_wait(hg_poll_set_t *poll_set, unsigned int timeout,
     unsigned int max_events, struct hg_poll_event *events,
     unsigned int *actual_events)
 {
-    int max_poll_events = (int) MIN(max_events, HG_POLL_MAX_EVENTS);
+    int max_poll_events = (int) MIN(max_events, poll_set->max_events);
     int nfds = 0, i;
     int ret = HG_UTIL_SUCCESS;
 
-    HG_UTIL_CHECK_ERROR(!poll_set, done, ret, HG_UTIL_FAIL, "NULL poll set");
-
-    if (timeout && (!poll_set->try_wait_cb ||
-                       (poll_set->try_wait_cb &&
-                           poll_set->try_wait_cb(poll_set->try_wait_arg)))) {
 #if defined(_WIN32)
 
 #elif defined(HG_UTIL_HAS_SYSEPOLL_H)
-        struct epoll_event poll_events[HG_POLL_MAX_EVENTS];
+    nfds = epoll_wait(
+        poll_set->fd, poll_set->events, max_poll_events, (int) timeout);
+    HG_UTIL_CHECK_ERROR(nfds == -1 && errno != EINTR, done, ret, HG_UTIL_FAIL,
+        "epoll_wait() failed (%s)", strerror(errno));
 
-        nfds = epoll_wait(
-            poll_set->fd, poll_events, max_poll_events, (int) timeout);
-        HG_UTIL_CHECK_ERROR(nfds == -1 && errno != EINTR, done, ret,
-            HG_UTIL_FAIL, "epoll_wait() failed (%s)", strerror(errno));
+    for (i = 0; i < nfds; ++i) {
+        events[i].events = 0;
+        events[i].data.u64 = (hg_util_uint64_t) poll_set->events[i].data.u64;
 
-        for (i = 0; i < nfds; ++i) {
-            struct hg_poll_data *hg_poll_data =
-                (struct hg_poll_data *) poll_events[i].data.ptr;
-            int error = 0, rc;
+        if (poll_set->events[i].events & EPOLLIN)
+            events[i].events |= HG_POLLIN;
 
-            HG_UTIL_CHECK_ERROR(hg_poll_data == NULL, done, ret, HG_UTIL_FAIL,
-                "NULL poll data");
+        if (poll_set->events[i].events & EPOLLOUT)
+            events[i].events |= HG_POLLOUT;
 
-            /* Don't change the if/else order */
-            if (poll_events[i].events & EPOLLERR)
-                error = EPOLLERR;
-            else if (poll_events[i].events & EPOLLHUP)
-                error = EPOLLHUP;
-            else if (poll_events[i].events & EPOLLRDHUP)
-                error = EPOLLRDHUP;
-
-            HG_UTIL_CHECK_ERROR(!(poll_events[i].events & (EPOLLIN | EPOLLOUT)),
-                done, ret, HG_UTIL_FAIL, "Unsupported events");
-
-            if (!hg_poll_data->poll_cb)
-                continue;
-
-            rc = hg_poll_data->poll_cb(
-                hg_poll_data->poll_arg, error, &events[i]);
-            HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
-                "poll cb failed");
-        }
-#elif defined(HG_UTIL_HAS_SYSEVENT_H)
-        struct kevent poll_events[HG_POLL_MAX_EVENTS];
-        struct timespec timeout_spec;
-        ldiv_t ld;
-
-        /* Get sec / nsec */
-        ld = ldiv(timeout, 1000L);
-        timeout_spec.tv_sec = ld.quot;
-        timeout_spec.tv_nsec = ld.rem * 1000000L;
-
-        nfds = kevent(
-            poll_set->fd, NULL, 0, poll_events, max_events, &timeout_spec);
-        HG_UTIL_CHECK_ERROR(nfds == -1 && errno != EINTR, done, ret,
-            HG_UTIL_FAIL, "kevent() failed (%s)", strerror(errno));
-
-        for (i = 0; i < nfds; ++i) {
-            struct hg_poll_data *hg_poll_data =
-                (struct hg_poll_data *) poll_events[i].udata;
-            int rc;
-
-            HG_UTIL_CHECK_ERROR(hg_poll_data == NULL, done, ret, HG_UTIL_FAIL,
-                "NULL poll data");
-
-            if (!hg_poll_data->poll_cb)
-                continue;
-
-            rc = hg_poll_data->poll_cb(hg_poll_data->poll_arg, 0, &events[i]);
-            HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
-                "poll cb failed");
-        }
-#else
-        struct pollfd poll_events[HG_POLL_MAX_EVENTS] = {0};
-        struct hg_poll_data *poll_data_events[HG_POLL_MAX_EVENTS] = {NULL};
-        struct hg_poll_data *hg_poll_data = NULL;
-        int nevents = 0;
-
-        /* Reset revents */
-        hg_thread_spin_lock(&poll_set->poll_data_list_lock);
-        for (hg_poll_data = HG_LIST_FIRST(&poll_set->poll_data_list);
-             hg_poll_data && (nevents < max_poll_events);
-             hg_poll_data = HG_LIST_NEXT(hg_poll_data, entry), nevents++) {
-            poll_events[nevents] = hg_poll_data->pollfd;
-            poll_data_events[nevents] = hg_poll_data;
-        }
-        hg_thread_spin_unlock(&poll_set->poll_data_list_lock);
-
-        nfds = poll(poll_events, nevents, (int) timeout);
-        HG_UTIL_CHECK_ERROR(nfds == -1 && errno != EINTR, done, ret,
-            HG_UTIL_FAIL, "poll() failed (%s)", strerror(errno));
-
-        /* An event on one of the fds has occurred. */
-        for (i = 0; i < nfds; ++i) {
-            int rc;
-
-            if (!(poll_events[i].revents & poll_events[i].events))
-                continue;
-
-            /* TODO check POLLHUP | POLLERR | POLLNVAL */
-            if (!poll_data_events[i]->poll_cb)
-                continue;
-
-            rc = poll_data_events[i]->poll_cb(
-                poll_data_events[i]->poll_arg, 0, &events[i]);
-            HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
-                "poll cb failed");
-        }
-
-        if (nfds) {
-            /* TODO should figure where to call hg_event_get() */
-            int rc = hg_event_set(poll_set->fd);
-            HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
-                "hg_event_set() failed (%s)", strerror(errno));
-        }
-#endif
-    } else {
-#ifdef _WIN32
-
-#else
-        struct hg_poll_data *poll_data_events[HG_POLL_MAX_EVENTS] = {NULL};
-        struct hg_poll_data *hg_poll_data;
-        int nevents = 0;
-
-        /* Reset revents */
-        hg_thread_spin_lock(&poll_set->poll_data_list_lock);
-        for (hg_poll_data = HG_LIST_FIRST(&poll_set->poll_data_list);
-             hg_poll_data && (nevents < max_poll_events);
-             hg_poll_data = HG_LIST_NEXT(hg_poll_data, entry), nevents++)
-            poll_data_events[nevents] = hg_poll_data;
-        hg_thread_spin_unlock(&poll_set->poll_data_list_lock);
-
-        nfds = nevents;
-        for (i = 0; i < nfds; ++i) {
-            int rc;
-
-            if (!poll_data_events[i]->poll_cb)
-                continue;
-
-            rc = poll_data_events[i]->poll_cb(
-                poll_data_events[i]->poll_arg, 0, &events[i]);
-            HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
-                "poll cb failed");
-        }
-#endif
+        /* Don't change the if/else order */
+        if (poll_set->events[i].events & EPOLLERR)
+            events[i].events |= HG_POLLERR;
+        else if (poll_set->events[i].events & EPOLLHUP)
+            events[i].events |= HG_POLLHUP;
+        else if (poll_set->events[i].events & EPOLLRDHUP)
+            events[i].events |= HG_POLLHUP;
     }
+
+    /* Grow array if reached max number */
+    if ((nfds == (int) poll_set->max_events) &&
+        (poll_set->max_events * 2 <= HG_POLL_MAX_EVENTS)) {
+        poll_set->events = realloc(poll_set->events,
+            sizeof(*poll_set->events) * poll_set->max_events * 2);
+        HG_UTIL_CHECK_ERROR(!poll_set->events, done, ret, HG_UTIL_FAIL,
+            "realloc() failed (%s)", strerror(errno));
+
+        poll_set->max_events *= 2;
+    }
+#elif defined(HG_UTIL_HAS_SYSEVENT_H)
+    struct timespec timeout_spec;
+    ldiv_t ld;
+
+    /* Get sec / nsec */
+    ld = ldiv(timeout, 1000L);
+    timeout_spec.tv_sec = ld.quot;
+    timeout_spec.tv_nsec = ld.rem * 1000000L;
+
+    nfds = kevent(
+        poll_set->fd, NULL, 0, poll_set->events, max_events, &timeout_spec);
+    HG_UTIL_CHECK_ERROR(nfds == -1 && errno != EINTR, done, ret, HG_UTIL_FAIL,
+        "kevent() failed (%s)", strerror(errno));
+
+    for (i = 0; i < nfds; ++i) {
+        events[i].events = 0;
+        events[i].data.ptr = (hg_util_uint64_t) poll_set->events[i].udata;
+
+        if (poll_set->events[i].flags & EVFILT_READ)
+            events[i].events |= HG_POLLIN;
+
+        if (poll_set->events[i].flags & EVFILT_WRITE)
+            events[i].events |= HG_POLLOUT;
+    }
+
+    /* Grow array if reached max number */
+    if ((nfds == (int) poll_set->max_events) &&
+        (poll_set->max_events * 2 <= HG_POLL_MAX_EVENTS)) {
+        poll_set->events = realloc(poll_set->events,
+            sizeof(*poll_set->events) * poll_set->max_events * 2);
+        HG_UTIL_CHECK_ERROR(!poll_set->events, done, ret, HG_UTIL_FAIL,
+            "realloc() failed (%s)", strerror(errno));
+
+        poll_set->max_events *= 2;
+    }
+#else
+    int nevent = 0, rc;
+    hg_util_bool_t signaled;
+
+    rc = hg_event_get(poll_set->fd, &signaled);
+    HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
+        "hg_event_get() failed (%s)", strerror(errno));
+    if (signaled) {
+        /* Should we do anything in that case? */
+    }
+
+    hg_thread_mutex_lock(&poll_set->lock);
+
+    /* Reset revents */
+    for (i = 0; i < (int) poll_set->nfds; i++)
+        poll_set->events[i].revents = 0;
+
+    nfds = poll(poll_set->events, (nfds_t) poll_set->nfds, (int) timeout);
+    HG_UTIL_CHECK_ERROR(nfds == -1 && errno != EINTR, unlock, ret, HG_UTIL_FAIL,
+        "poll() failed (%s)", strerror(errno));
+
+    nfds = (int) MIN(max_poll_events, nfds);
+
+    /* An event on one of the fds has occurred. */
+    for (i = 0; i < (int) poll_set->nfds && nevent < nfds; ++i) {
+        events[i].events = 0;
+        events[i].data.u64 = (hg_util_uint64_t) poll_set->event_data[i].u64;
+
+        if (poll_set->events[i].revents & POLLIN)
+            events[i].events |= HG_POLLIN;
+
+        if (poll_set->events[i].revents & POLLOUT)
+            events[i].events |= HG_POLLOUT;
+
+        /* Don't change the if/else order */
+        if (poll_set->events[i].revents & POLLERR)
+            events[i].events |= HG_POLLERR;
+        else if (poll_set->events[i].revents & POLLHUP)
+            events[i].events |= HG_POLLHUP;
+        else if (poll_set->events[i].events & POLLNVAL)
+            events[i].events |= HG_POLLERR;
+
+        nevent++;
+    }
+
+    hg_thread_mutex_unlock(&poll_set->lock);
+
+    HG_UTIL_CHECK_ERROR(nevent != nfds, done, ret, HG_UTIL_FAIL,
+        "found only %d events, expected %d", nevent, nfds);
+
+    if (nfds > 0) {
+        /* TODO should figure where to call hg_event_get() */
+        rc = hg_event_set(poll_set->fd);
+        HG_UTIL_CHECK_ERROR(rc != HG_UTIL_SUCCESS, done, ret, HG_UTIL_FAIL,
+            "hg_event_set() failed (%s)", strerror(errno));
+    }
+#endif
 
     if (actual_events)
         *actual_events = (unsigned int) nfds;
 
 done:
     return ret;
+
+#if !defined(_WIN32) && !defined(HG_UTIL_HAS_SYSEPOLL_H) &&                    \
+    !defined(HG_UTIL_HAS_SYSEVENT_H)
+unlock:
+    hg_thread_mutex_unlock(&poll_set->lock);
+
+    return ret;
+#endif
 }

--- a/src/util/mercury_poll.h
+++ b/src/util/mercury_poll.h
@@ -13,43 +13,23 @@
 
 #include "mercury_util_config.h"
 
-/**
- * Purpose: define an interface that either polls or allows busy wait
- * without entering system calls.
- */
-
 /*************************************/
 /* Public Type and Struct Definition */
 /*************************************/
 
 typedef struct hg_poll_set hg_poll_set_t;
 
+typedef union hg_poll_data {
+    void *ptr;
+    int fd;
+    hg_util_uint32_t u32;
+    hg_util_uint64_t u64;
+} hg_poll_data_t;
+
 struct hg_poll_event {
-    hg_util_bool_t progressed; /* Indicates progress */
-    void *ptr;                 /* Pointer to user data */
+    hg_util_uint32_t events; /* Poll events */
+    hg_poll_data_t data;     /* User data variable */
 };
-
-/**
- * Callback that can be used to signal when it is safe to block on the
- * poll set or if blocking could hang the application.
- *
- * \param arg [IN]              function argument
- *
- * \return HG_UTIL_TRUE if it is safe to block or HG_UTIL_FALSE otherwise
- */
-typedef hg_util_bool_t (*hg_poll_try_wait_cb_t)(void *arg);
-
-/**
- * Polling callback, arg can be used to pass user arguments, event can be used
- * to return user arguments back to hg_poll_wait.
- *
- * \param arg [IN]              pointer to user data
- * \param error [IN]            any error event has occurred
- * \param ptr [OUT]             event data output
- *
- * \return Non-negative on success or negative on failure
- */
-typedef int (*hg_poll_cb_t)(void *arg, int error, struct hg_poll_event *event);
 
 /*****************/
 /* Public Macros */
@@ -58,8 +38,10 @@ typedef int (*hg_poll_cb_t)(void *arg, int error, struct hg_poll_event *event);
 /**
  * Polling events.
  */
-#define HG_POLLIN  0x001 /* Ready to read.   */
-#define HG_POLLOUT 0x004 /* Ready to write.  */
+#define HG_POLLIN  0x001 /* There is data to read. */
+#define HG_POLLOUT 0x004 /* Writing now will not block. */
+#define HG_POLLERR 0x008 /* Error condition. */
+#define HG_POLLHUP 0x010 /* Hung up. */
 
 /*********************/
 /* Public Prototypes */
@@ -80,7 +62,7 @@ hg_poll_create(void);
 /**
  * Destroy a poll set.
  *
- * \param poll_set [IN]         pointer to poll set
+ * \param poll_set [IN/OUT]     pointer to poll set
  *
  * \return Non-negative on success or negative on failure
  */
@@ -98,34 +80,16 @@ HG_UTIL_PUBLIC int
 hg_poll_get_fd(hg_poll_set_t *poll_set);
 
 /**
- * Set a callback that can be used to signal when it is safe to block on the
- * poll set or if blocking could hang the application, in which case behavior
- * is the same as passing a timeout of 0.
- *
- * \param poll_set [IN]         pointer to poll set
- * \param try_wait_cb [IN]      function pointer
- * \param try_wait_arg [IN]     function pointer argument
- *
- * \return Non-negative on success or negative on failure
- */
-HG_UTIL_PUBLIC int
-hg_poll_set_try_wait(hg_poll_set_t *poll_set, hg_poll_try_wait_cb_t try_wait_cb,
-    void *try_wait_arg);
-
-/**
  * Add file descriptor to poll set.
  *
  * \param poll_set [IN]         pointer to poll set
  * \param fd [IN]               file descriptor
- * \param flags [IN]            polling flags (HG_POLLIN, etc)
- * \param poll_cb [IN]          function pointer
- * \param poll_cb_args [IN]     function pointer argument
+ * \param event [IN]            pointer to event struct
  *
  * \return Non-negative on success or negative on failure
  */
 HG_UTIL_PUBLIC int
-hg_poll_add(hg_poll_set_t *poll_set, int fd, unsigned int flags,
-    hg_poll_cb_t poll_cb, void *poll_cb_arg);
+hg_poll_add(hg_poll_set_t *poll_set, int fd, struct hg_poll_event *event);
 
 /**
  * Remove file descriptor from poll set.
@@ -139,16 +103,13 @@ HG_UTIL_PUBLIC int
 hg_poll_remove(hg_poll_set_t *poll_set, int fd);
 
 /**
- * Wait on a poll set for timeout ms, progressed indicating whether progress has
- * been made after that call returns. If timeout is 0, progress is performed
- * on all the registered polling callbacks and hg_poll_wait() exits as soon as
- * progress is made. If timeout is non 0, the system dependent polling function
- * call is entered and progress is performed on the list of file descriptors
- * for which an event has occurred.
+ * Wait on a poll set for timeout ms, and return at most max_events.
  *
  * \param poll_set [IN]         pointer to poll set
  * \param timeout [IN]          timeout (in milliseconds)
- * \param progressed [OUT]      pointer to boolean indicating progress made
+ * \param max_events [IN]       max number of events
+ * \param events [IN/OUT]       array of events to be returned
+ * \param actual_events [OUT]   actual number of events returned
  *
  * \return Non-negative on success or negative on failure
  */


### PR DESCRIPTION
This simplifies the current polling mechanism by no longer using callbacks for hg_poll_add() routines and unifies previous hg_core_progress_na() and hg_core_progress_poll() routines. It also prevents extra stack allocations by preallocating event arrays.