### PR TITLE
bulk: fix an bug in hg_bulk_transfer_cb

### DIFF
--- a/src/mercury_bulk.c
+++ b/src/mercury_bulk.c
@@ -649,8 +649,8 @@ hg_bulk_transfer_cb(const struct na_cb_info *callback_info)
     /* If canceled, mark handle as canceled */
     if (callback_info->ret == NA_CANCELED)
         hg_atomic_cas32(&hg_bulk_op_id->canceled, 0, 1);
-    else
-        HG_CHECK_ERROR_NORET(callback_info->ret != NA_SUCCESS, done,
+    else if (callback_info->ret != NA_SUCCESS)
+        HG_LOG_ERROR(
             "Error in NA callback (s)", NA_Error_to_string(callback_info->ret));
 
     /* When all NA transfers that correspond to bulk operation complete


### PR DESCRIPTION
When the bulk transfer failed, should increase op_completed_count
and complete the bulk when needed, or the bulk possibly cannot complete
forever.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>