### PR TITLE
use epoll_wait() in na_sm even with timeout 0

### DIFF
--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -4531,7 +4531,7 @@ na_sm_progress(
         if (timeout)
             hg_time_get_current_ms(&t1);
 
-        if (timeout && na_sm_endpoint->poll_set) {
+        if (na_sm_endpoint->poll_set) {
             unsigned int nevents = 0, i;
             /* Just wait on a single event, anything greater may increase
              * latency, and slow down progress, we will not wait next round


### PR DESCRIPTION
This slightly alters the logic in na_sm_progress() so that it calls epoll_wait() (by way of hg_poll_wait()) even when the timeout is zero as long as a poll_set is present.

The reason is for performance; if the poll_wait() is not called, then na_sm must call both recvmsg() and read() in case unexpected messages are present.  The former in particular is more expensive than epoll_wait() with a zero timeout.

Output below shows the average response time difference (dropped from 3.3 usec to 2.6 usec) for a Mochi sdskv benchmark with a single process.  This example is not actually doing any na communication at all (all operations are "self" RPCs), but there is a performance difference anyway because mercury must check the active na+sm transport on every iteration.

```
test case:

[carns@carns-x1-7g null]$ cat baseline-64k-puts-sm.json
{
    "protocol" : "na+sm",
    "seed" : 0,
    "server" : {
        "use-progress-thread" : false,
        "rpc-thread-count" : 0,
        "database" : {
            "type" : "null",
            "name" : "benchmark-db",
            "path" : "/tmp/sdskv"
        }
    },
    "benchmarks" : [
        {
            "type" : "put",
            "repetitions" : 65536,
            "num-entries" : 1,
            "key-sizes" : [ 8, 32 ],
            "val-sizes" : [ 24, 48 ],
            "erase-on-teardown" : true
        }
    ]
}

single-process performance before change:

[carns@carns-x1-7g null]$ sdskv-benchmark baseline-64k-puts-sm.json
================ put ================
{
	"erase-on-teardown" : true,
	"key-sizes" : [ 8, 32 ],
	"num-entries" : 1,
	"repetitions" : 65536,
	"type" : "put",
	"val-sizes" : [ 24, 48 ]
}
-------------------------------------
Samples         : 65536
Average(sec)    : 0.000003345
Variance(sec^2) : 0.000000000
StdDev(sec)     : 0.000005673
Minimum(sec)    : 0.000002861
Q1(sec)         : 0.000003099
Median(sec)     : 0.000003099
Q3(sec)         : 0.000003338
Maximum(sec)    : 0.000670195

after change:

[carns@carns-x1-7g null]$ sdskv-benchmark baseline-64k-puts-sm.json
================ put ================
{
	"erase-on-teardown" : true,
	"key-sizes" : [ 8, 32 ],
	"num-entries" : 1,
	"repetitions" : 65536,
	"type" : "put",
	"val-sizes" : [ 24, 48 ]
}
-------------------------------------
Samples         : 65536
Average(sec)    : 0.000002660
Variance(sec^2) : 0.000000000
StdDev(sec)     : 0.000004737
Minimum(sec)    : 0.000002146
Q1(sec)         : 0.000002384
Median(sec)     : 0.000002384
Q3(sec)         : 0.000002623
Maximum(sec)    : 0.000395060
```
FWIW I was looking at this path in an attempt to figure out where the outliers (the "Maximum" field in the output).  This PR does not address that, though; still looking.