### PR TITLE
HG util: fix timeout passed to pthread_cond_timedwait()

### DIFF
--- a/src/util/mercury_thread_condition.c
+++ b/src/util/mercury_thread_condition.c
@@ -22,8 +22,9 @@ hg_thread_cond_init(hg_thread_cond_t *cond)
     pthread_condattr_init(&attr);
 #    if defined(HG_UTIL_HAS_PTHREAD_CONDATTR_SETCLOCK) &&                      \
         defined(HG_UTIL_HAS_CLOCK_MONOTONIC_COARSE)
-    /* Must set clock ID if using different clock */
-    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC_COARSE);
+    /* Must set clock ID if using different clock
+     * (CLOCK_MONOTONIC_COARSE not supported here) */
+    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
 #    endif
     if (pthread_cond_init(cond, &attr))
         return HG_UTIL_FAIL;

--- a/src/util/mercury_thread_condition.h
+++ b/src/util/mercury_thread_condition.h
@@ -161,15 +161,16 @@ hg_thread_cond_timedwait(
     clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
 
     /* Get sec / nsec */
-    ld = ldiv(now.tv_nsec + timeout * 1000000L, 1000000L);
+    ld = ldiv(now.tv_nsec + timeout * 1000000L, 1000000000L);
+    abs_timeout.tv_nsec = ld.rem;
 #    elif defined(HG_UTIL_HAS_SYSTIME_H)
     gettimeofday(&now, NULL);
 
-    /* Get sec / nsec */
+    /* Get sec / usec */
     ld = ldiv(now.tv_usec + timeout * 1000L, 1000000L);
+    abs_timeout.tv_nsec = ld.rem * 1000L;
 #    endif
     abs_timeout.tv_sec = now.tv_sec + ld.quot;
-    abs_timeout.tv_nsec = ld.rem * 1000L;
 
     if (pthread_cond_timedwait(cond, mutex, &abs_timeout))
         return HG_UTIL_FAIL;


### PR DESCRIPTION
CLOCK_MONOTONIC_COARSE cannot be passed to pthread_condattr_setclock or it causes pthread_cond_timedwait() to return early. This was causing HG_Trigger() to excessively spin when a timeout was passed.