### PR TITLE
HG util: remove check for STDERR_FILENO (fix #428)

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -1127,7 +1127,7 @@ hg_core_context_create(hg_core_class_t *hg_core_class, hg_uint8_t id,
         event.data.u32 = (hg_util_uint32_t) HG_CORE_POLL_NA;
         rc = hg_poll_add(context->poll_set, na_poll_fd, &event);
         HG_CHECK_ERROR(rc != HG_UTIL_SUCCESS, error, ret, HG_NOMEM,
-            "hg_poll_add() failed");
+            "hg_poll_add() failed (na_poll_fd=%d)", na_poll_fd);
 
 #ifdef NA_HAS_SM
         if (context->core_context.na_sm_context) {
@@ -1139,7 +1139,7 @@ hg_core_context_create(hg_core_class_t *hg_core_class, hg_uint8_t id,
             event.data.u32 = (hg_util_uint32_t) HG_CORE_POLL_SM;
             rc = hg_poll_add(context->poll_set, na_poll_fd, &event);
             HG_CHECK_ERROR(rc != HG_UTIL_SUCCESS, error, ret, HG_NOMEM,
-                "hg_poll_add() failed");
+                "hg_poll_add() failed (na_poll_fd=%d)", na_poll_fd);
         }
 #endif
 
@@ -1154,7 +1154,7 @@ hg_core_context_create(hg_core_class_t *hg_core_class, hg_uint8_t id,
             rc = hg_poll_add(
                 context->poll_set, context->completion_queue_notify, &event);
             HG_CHECK_ERROR(rc != HG_UTIL_SUCCESS, error, ret, HG_NOMEM,
-                "hg_poll_add() failed");
+                "hg_poll_add() failed (na_poll_fd=%d)", na_poll_fd);
         }
     }
 

--- a/src/util/mercury_poll.c
+++ b/src/util/mercury_poll.c
@@ -193,9 +193,6 @@ hg_poll_add(hg_poll_set_t *poll_set, int fd, struct hg_poll_event *event)
 #endif
     int ret = HG_UTIL_SUCCESS;
 
-    HG_UTIL_CHECK_ERROR(fd <= STDERR_FILENO, done, ret, HG_UTIL_FAIL,
-        "fd is not valid (%d)", fd);
-
 #if defined(_WIN32)
     /* TODO */
 #elif defined(HG_UTIL_HAS_SYSEPOLL_H)
@@ -289,9 +286,6 @@ hg_poll_remove(hg_poll_set_t *poll_set, int fd)
     int i, found = -1;
 #endif
     int ret = HG_UTIL_SUCCESS;
-
-    HG_UTIL_CHECK_ERROR(fd <= STDERR_FILENO, done, ret, HG_UTIL_FAIL,
-        "fd is not valid (%d)", fd);
 
 #if defined(_WIN32)
     /* TODO */


### PR DESCRIPTION
Returning an error when adding a file descriptor lower than STDERR_FILENO
was causing errors when users were closing those std file descriptors