### PR TITLE
na sm: check if entry is in poll list

### DIFF
--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -3861,7 +3861,8 @@ na_sm_addr_free(na_class_t *na_class, na_addr_t addr)
 
     /* Remove address from list of addresses to poll */
     hg_thread_spin_lock(&na_sm_endpoint->poll_addr_list.lock);
-    HG_LIST_REMOVE(na_sm_addr, entry);
+    if (na_sm_addr->entry.next || na_sm_addr->entry.prev)
+        HG_LIST_REMOVE(na_sm_addr, entry);
     hg_thread_spin_unlock(&na_sm_endpoint->poll_addr_list.lock);
 
     ret = na_sm_addr_destroy(


### PR DESCRIPTION
### Description

on `na_sm_addr_free`, there is a possibility that `na_sm_addr` is not in  list of addresses to poll.

For example, like the code of https://github.com/mercury-hpc/mercury/issues/445 , it can happen if we call `NA_Addr_free` without doing forwarding.

### Additional context

Currently due to issue https://github.com/mercury-hpc/mercury/issues/445 , these processes are not performed because the refcount is always 1 or more.

However, after fixing https://github.com/mercury-hpc/mercury/issues/445 , this case can occur.

### Additional context 2

I Implemented this with reference to `na_ofi_domain_close` in `na_ofi.c`

https://github.com/mercury-hpc/mercury/blob/4325efabcdaf5d0a8847015aac7ab9c168f9b38b/src/na/na_ofi.c#L2311