### PR TITLE
NA SM: add sm_info_string field to HG init info

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -935,11 +935,21 @@ hg_core_init(const char *na_info_string, hg_bool_t na_listen,
 
     /* Initialize SM plugin */
     if (auto_sm) {
+        char info_string[HG_CORE_ADDR_MAX_SIZE], *info_string_p;
         na_return_t na_ret;
 
+        if (hg_init_info && hg_init_info->sm_info_string) {
+            int rc = snprintf(info_string, HG_CORE_ADDR_MAX_SIZE, "na+sm://%s",
+                hg_init_info->sm_info_string);
+            HG_CHECK_ERROR(rc < 0 || rc > HG_CORE_ADDR_MAX_SIZE, error, ret,
+                HG_OVERFLOW, "snprintf() failed, rc: %d", rc);
+            info_string_p = info_string;
+        } else
+            info_string_p = "na+sm";
+
         /* Initialize NA SM first so that tmp directories are created */
-        hg_core_class->core_class.na_sm_class =
-            NA_Initialize_opt("na+sm", na_listen, &hg_init_info->na_init_info);
+        hg_core_class->core_class.na_sm_class = NA_Initialize_opt(
+            info_string_p, na_listen, &hg_init_info->na_init_info);
         HG_CHECK_ERROR(hg_core_class->core_class.na_sm_class == NULL, error,
             ret, HG_NA_ERROR, "Could not initialize NA SM class");
 

--- a/src/mercury_core_types.h
+++ b/src/mercury_core_types.h
@@ -54,6 +54,12 @@ struct hg_init_info {
      * Default is: false */
     hg_bool_t auto_sm;
 
+    /* Overrides the default info string used to initialize the NA shared-memory
+     * interface when auto_sm is set to true (e.g., "foo-bar" will create
+     * shared-memory objects and directories using "foo-bar" as a suffix).
+     * Default is: null */
+    const char *sm_info_string;
+
     /* Controls whether mercury should _NOT_ attempt to transfer small bulk data
      * along with the RPC request.
      * Default is: false */
@@ -150,8 +156,8 @@ typedef enum {
 /* HG init info initializer */
 #define HG_INIT_INFO_INITIALIZER                                               \
     {                                                                          \
-        NA_INIT_INFO_INITIALIZER, NULL, 0, 0, HG_FALSE, HG_FALSE, HG_FALSE,    \
-            HG_FALSE                                                           \
+        NA_INIT_INFO_INITIALIZER, NULL, 0, 0, HG_FALSE, NULL, HG_FALSE,        \
+            HG_FALSE, HG_FALSE                                                 \
     }
 
 #endif /* MERCURY_CORE_TYPES_H */


### PR DESCRIPTION
Allows for specification of shared-memory file suffix to use with auto_sm