### PR TITLE
NA OFI: use NA IP check module and add missing NA_OFI_VERIFY_PROV_DOM

### DIFF
--- a/src/na/na_ip.h
+++ b/src/na/na_ip.h
@@ -31,13 +31,14 @@ extern "C" {
  * Parse a subnet specification string.
  *
  * \param spec  [IN]    the specification string to parse
- * \param netp  [OUT]   pointer to where to put network info
- * \param maskp [OUT]   pointer to where to put the netmask info
+ * \param net_p  [OUT]  pointer to where to put network info
+ * \param mask_p [OUT]  pointer to where to put the netmask info
  *
  * \return NA_SUCCESS or corresponding NA error code
  */
 NA_PRIVATE na_return_t
-na_ip_parse_subnet(const char *spec, na_uint32_t *netp, na_uint32_t *netmaskp);
+na_ip_parse_subnet(
+    const char *spec, na_uint32_t *net_p, na_uint32_t *netmask_p);
 
 /**
  * Get preferred ip address (based on provided subnet).
@@ -52,18 +53,22 @@ NA_PRIVATE na_return_t
 na_ip_pref_addr(na_uint32_t net, na_uint32_t netmask, char *outstr);
 
 /**
- * Return interface name and sockaddr from a given hostname / port.
+ * Return interface name and sockaddr from a given hostname / port. If non-null,
+ * \sa_p must be freed after its use. If non-null \ifa_name must be freed after
+ * its use.
  *
- * \param hostname [IN]         hostname to resolve
+ * \param name [IN]             name to resolve (host or ifa name)
  * \param port [IN]             port to use
- * \param ifa_name [OUT]        returned iface name
- * \param ss_ptr [OUT]          returned pointer to usable sockaddr
+ * \param family [IN]           address family to use (AF_UNSPEC if any)
+ * \param ifa_name_p [OUT]      returned iface name
+ * \param sa_p [OUT]            returned pointer to usable sockaddr
+ * \param salen_p [OUT]         returned length of address
  *
  * \return NA_SUCCESS or corresponding NA error code
  */
 NA_PRIVATE na_return_t
-na_ip_check_interface(const char *hostname, unsigned int port, char **ifa_name,
-    struct sockaddr_storage **ss_ptr);
+na_ip_check_interface(const char *name, unsigned int port, int family,
+    char **ifa_name_p, struct sockaddr **sa_p, socklen_t *salen_p);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
… for tcp provider

Clean up ip and domain checking

NA IP: refactor na_ip_check_interface() to only use getaddrinfo() and getifaddrs()

Add family argument to force detection of IPv4/IPv6 addresses