### PR TITLE
NA OFI: add support for HPE CXI provider

### DIFF
--- a/src/na/CMakeLists.txt
+++ b/src/na/CMakeLists.txt
@@ -141,6 +141,7 @@ if(NA_USE_OFI)
   # Detect <rdma/fi_ext_gni.h>
   set(CMAKE_REQUIRED_INCLUDES ${OFI_INCLUDE_DIR})
   check_include_files("rdma/fi_ext_gni.h" NA_OFI_HAS_EXT_GNI_H)
+  check_include_files("rdma/fabric.h;rdma/fi_cxi_ext.h" NA_OFI_HAS_EXT_CXI_H)
   if(NA_OFI_HAS_EXT_GNI_H)
     option(NA_OFI_GNI_USE_UDREG "Force gni provider to use udreg instead of internal MR cache." OFF)
     if(NA_OFI_GNI_USE_UDREG)

--- a/src/na/na_config.h.in
+++ b/src/na/na_config.h.in
@@ -98,6 +98,7 @@ typedef na_uint64_t na_ptr_t;
 /* OFI */
 #cmakedefine NA_HAS_OFI
 #cmakedefine NA_OFI_HAS_EXT_GNI_H
+#cmakedefine NA_OFI_HAS_EXT_CXI_H
 #cmakedefine NA_OFI_GNI_HAS_UDREG
 
 /* NA SM */


### PR DESCRIPTION
Clean up provider table and add EP proto

Add support for FI_MR_ENDPOINT mr mode

Co-authored-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>