### PR TITLE
HG core: remove MERCURY_ENABLE_STATS CMake option and use 'diag' log …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,12 +94,6 @@ if(MERCURY_USE_CHECKSUMS)
   endif()
 endif()
 
-# Collect statistics
-option(MERCURY_ENABLE_STATS "Enable collection of stats that can be printed at exit." OFF)
-if(MERCURY_ENABLE_STATS)
-  set(HG_HAS_COLLECT_STATS 1)
-endif()
-
 # XDR
 option(MERCURY_USE_XDR "Use XDR for generic encoding." OFF)
 if(MERCURY_USE_XDR)

--- a/src/mercury_config.h.in
+++ b/src/mercury_config.h.in
@@ -85,7 +85,6 @@ typedef hg_uint8_t hg_bool_t;
 #cmakedefine HG_HAS_BOOST
 #cmakedefine HG_HAS_CHECKSUMS
 #cmakedefine HG_HAS_XDR
-#cmakedefine HG_HAS_COLLECT_STATS
 
 #cmakedefine HG_HAS_DEBUG
 

--- a/src/mercury_core_types.h
+++ b/src/mercury_core_types.h
@@ -67,10 +67,6 @@ struct hg_init_info {
      * that option.
      * Default is: false */
     hg_bool_t no_loopback;
-
-    /* (Debug) Print stats at exit.
-     * Default is: false */
-    hg_bool_t stats;
 };
 
 /* Error return codes:
@@ -153,7 +149,7 @@ typedef enum {
 #define HG_INIT_INFO_INITIALIZER                                               \
     {                                                                          \
         NA_INIT_INFO_INITIALIZER, NULL, 0, 0, HG_FALSE, NULL, HG_FALSE,        \
-            HG_FALSE, HG_FALSE                                                 \
+            HG_FALSE                                                           \
     }
 
 #endif /* MERCURY_CORE_TYPES_H */

--- a/src/util/mercury_dlog.h
+++ b/src/util/mercury_dlog.h
@@ -229,6 +229,20 @@ hg_dlog_dump(struct hg_dlog *d, int (*log_func)(FILE *, const char *, ...),
     FILE *stream, int trylock);
 
 /**
+ * dump dlog counters to a stream. set trylock if you want to dump even
+ * if it is locked (e.g. you are crashing and you don't care about
+ * locking).
+ *
+ * \param d [IN]                dlog to dump
+ * \param log_func [IN]         log function to use (default printf)
+ * \param stream [IN]           stream to use
+ * \param trylock [IN]          just try to lock (warn if it fails)
+ */
+HG_UTIL_PUBLIC void
+hg_dlog_dump_counters(struct hg_dlog *d,
+    int (*log_func)(FILE *, const char *, ...), FILE *stream, int trylock);
+
+/**
  * dump dlog info to a file.   set trylock if you want to dump even
  * if it is locked (e.g. you are crashing and you don't care about
  * locking).  the output file is "base.log" or base-pid.log" depending

--- a/src/util/mercury_log.c
+++ b/src/util/mercury_log.c
@@ -197,9 +197,19 @@ hg_log_free_dlogs(void)
     struct hg_log_outlet *outlet;
 
     /* Free logs if any was attached */
-    HG_QUEUE_FOREACH (outlet, &hg_log_outlets_g, entry)
-        if (outlet->debug_log)
+    HG_QUEUE_FOREACH (outlet, &hg_log_outlets_g, entry) {
+        if (outlet->debug_log &&
+            !(outlet->parent && outlet->parent->debug_log)) {
+            if (outlet->level >= HG_LOG_LEVEL_MIN_DEBUG) {
+                FILE *stream = hg_log_streams_g[outlet->level]
+                                   ? hg_log_streams_g[outlet->level]
+                                   : *hg_log_std_streams_g[outlet->level];
+                hg_dlog_dump_counters(
+                    outlet->debug_log, hg_log_func_g, stream, 0);
+            }
             hg_dlog_free(outlet->debug_log);
+        }
+    }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/util/mercury_log.h
+++ b/src/util/mercury_log.h
@@ -4,77 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/*
- * Copyright (c) 2004, 2005, 2006, 2007 David Young.  All rights reserved.
- *
- * Copyright (c) 2004 Urbana-Champaign Independent Media Center.
- * All rights reserved.
- *
- *
- * Portions of hlog are Copyright (c) David Young.  The applicable copyright
- * notice and licensing terms are reproduced here:
- *
- * Copyright (c) 2004, 2005, 2006, 2007 David Young.  All rights reserved.
- *
- * This file contains code contributed by David Young.
- *
- * Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above
- *    copyright notice, this list of conditions and the following
- *    disclaimer in the documentation and/or other materials provided
- *    with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY DAVID YOUNG ``AS IS'' AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL DAVID
- * YOUNG BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
- * OF SUCH DAMAGE.
- *
- * -----------------------------------------------------------------------------
- * -----------------------------------------------------------------------------
- *
- * Portions of hlog are Copyright (c) Urbana-Champaign Independent Media Center.
- * The applicable copyright notice and licensing terms are reproduced here:
- *
- * Copyright (c) 2004 Urbana-Champaign Independent Media Center.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above
- *    copyright notice, this list of conditions and the following
- *    disclaimer in the documentation and/or other materials provided
- *    with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE URBANA-CHAMPAIGN INDEPENDENT
- * MEDIA CENTER ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED.  IN NO EVENT SHALL THE URBANA-CHAMPAIGN INDEPENDENT
- * MEDIA CENTER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 #ifndef MERCURY_LOG_H
 #define MERCURY_LOG_H
 
@@ -245,7 +174,7 @@
 
 /* HG_LOG_ADD_COUNTER64: add 64-bit debug log counter */
 #define HG_LOG_ADD_COUNTER64(name, counter_ptr, counter_name, counter_desc)    \
-    hg_dlog_mkcount64(HG_LOG_OUTLET(name)->debug_log, counter_ptr,             \
+    hg_dlog_mkcount64(HG_LOG_OUTLET(name).debug_log, counter_ptr,              \
         counter_name, counter_desc)
 
 /*************************************/

--- a/src/util/mercury_util_config.h.in
+++ b/src/util/mercury_util_config.h.in
@@ -73,9 +73,6 @@
 /* Define if has colored output */
 #cmakedefine HG_UTIL_HAS_LOG_COLOR
 
-/* Define if has <opa_primitives.h> */
-#cmakedefine HG_UTIL_HAS_OPA_PRIMITIVES_H
-
 /* Define if has 'pthread_condattr_setclock()' */
 #cmakedefine HG_UTIL_HAS_PTHREAD_CONDATTR_SETCLOCK
 


### PR DESCRIPTION
…subsys instead

Let mercury log print counters on exit when debug outlet is on

HG Core: refactor existing counters (used only if debug is on)