### PR TITLE
NA OFI: fix regression introduced in na_ofi_addr_to_string()

### DIFF
--- a/Testing/mercury_test.c
+++ b/Testing/mercury_test.c
@@ -622,6 +622,14 @@ HG_Test_init(int argc, char *argv[], struct hg_test_info *hg_test_info)
             done, ret, "HG_Addr_self() failed (%s)", HG_Error_to_string(ret));
 
         ret = HG_Addr_to_string(
+            hg_test_info->hg_class, NULL, &addr_string_len, self_addr);
+        HG_TEST_CHECK_HG_ERROR(done, ret, "HG_Addr_to_string() failed (%s)",
+            HG_Error_to_string(ret));
+        HG_TEST_CHECK_ERROR(addr_string_len > sizeof(addr_string), done, ret,
+            HG_OVERFLOW, "String length too large (%zu)",
+            (size_t) addr_string_len);
+
+        ret = HG_Addr_to_string(
             hg_test_info->hg_class, addr_string, &addr_string_len, self_addr);
         HG_TEST_CHECK_HG_ERROR(done, ret, "HG_Addr_to_string() failed (%s)",
             HG_Error_to_string(ret));

--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -3421,7 +3421,7 @@ na_ofi_get_uri(struct na_ofi_domain *na_ofi_domain, char *buf,
     } else
         fi_addr_str_ptr = fi_addr_str;
 
-    addr_strlen = strlen(fi_addr_str) +
+    addr_strlen = strlen(fi_addr_str_ptr) +
                   strlen(na_ofi_domain->fi_prov->fabric_attr->prov_name) + 3;
     if (buf) {
         NA_CHECK_SUBSYS_ERROR(addr, addr_strlen >= *buf_size_p, out, ret,
@@ -3431,7 +3431,9 @@ na_ofi_get_uri(struct na_ofi_domain *na_ofi_domain, char *buf,
         rc = snprintf(buf, *buf_size_p, "%s://%s",
             na_ofi_domain->fi_prov->fabric_attr->prov_name, fi_addr_str_ptr);
         NA_CHECK_SUBSYS_ERROR(addr, rc < 0 || rc > (int) *buf_size_p, out, ret,
-            NA_OVERFLOW, "snprintf() failed or name truncated, rc: %d", rc);
+            NA_OVERFLOW,
+            "snprintf() failed or name truncated, rc: %d (expected %zu)", rc,
+            (size_t) *buf_size_p);
     }
     *buf_size_p = addr_strlen + 1;
 


### PR DESCRIPTION
HG Test: check that length returned can be used in second call