### PR TITLE
NA OFI: rework handling of fi_info to open fabric/domain/endpoint

### DIFF
--- a/src/na/na_ip.c
+++ b/src/na/na_ip.c
@@ -115,6 +115,7 @@ na_ip_check_interface(const char *name, na_uint16_t port, int family,
     struct addrinfo hints, *addr_res = NULL;
     struct sockaddr_storage *ss_addr = NULL;
     socklen_t salen = 0;
+    const char *node = NULL;
     na_return_t ret = NA_SUCCESS;
     int rc;
 
@@ -156,7 +157,6 @@ na_ip_check_interface(const char *name, na_uint16_t port, int family,
             salen = sizeof(struct sockaddr_in6);
         }
     } else { /* Try to match against passed name */
-        const char *node = NULL;
         char service[NI_MAXSERV];
 
         /* Add port */
@@ -219,7 +219,7 @@ na_ip_check_interface(const char *name, na_uint16_t port, int family,
             ret, NA_ADDRNOTAVAIL, "No ifa_name match found for IP");
     }
 
-    if (ifaddr && ifa_name_p) {
+    if (ifaddr && ifa_name_p && node) {
         *ifa_name_p = strdup(ifaddr->ifa_name);
         NA_CHECK_SUBSYS_ERROR(ip, *ifa_name_p == NULL, done, ret, NA_NOMEM,
             "Could not dup ifa_name");

--- a/src/na/na_loc.c
+++ b/src/na/na_loc.c
@@ -112,8 +112,9 @@ na_loc_info_destroy(struct na_loc_info *na_loc_info)
 
 /*---------------------------------------------------------------------------*/
 na_bool_t
-na_loc_check_pcidev(struct na_loc_info *na_loc_info, unsigned int domain_id,
-    unsigned int bus_id, unsigned int device_id, unsigned int function_id)
+na_loc_check_pcidev(const struct na_loc_info *na_loc_info,
+    unsigned int domain_id, unsigned int bus_id, unsigned int device_id,
+    unsigned int function_id)
 {
 #ifdef NA_HAS_HWLOC
     hwloc_obj_t obj = NULL;

--- a/src/na/na_loc.h
+++ b/src/na/na_loc.h
@@ -57,8 +57,9 @@ na_loc_info_destroy(struct na_loc_info *na_loc_info);
  * \return NA_TRUE if they share the same cpu set, NA_FALSE otherwise
  */
 NA_PRIVATE na_bool_t
-na_loc_check_pcidev(struct na_loc_info *na_loc_info, unsigned int domain_id,
-    unsigned int bus_id, unsigned int device_id, unsigned int function_id);
+na_loc_check_pcidev(const struct na_loc_info *na_loc_info,
+    unsigned int domain_id, unsigned int bus_id, unsigned int device_id,
+    unsigned int function_id);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
(fix #554)

Separate fabric from domain and keep single domain per NA class

Refactor handling of scalable vs standard endpoints

Improve debug info to print verbose FI info of selected provider