### PR TITLE
NA Test: add -w option to control RMA buffer count (default is 64)

### DIFF
--- a/Testing/na/na_test.c
+++ b/Testing/na/na_test.c
@@ -97,7 +97,9 @@ na_test_usage(const char *execname)
     printf("    -b, --busy           Busy wait\n");
     printf("    -y  --buf_size_min   Min buffer size (in bytes)\n");
     printf("    -z, --buf_size_max   Max buffer size (in bytes)\n");
+    printf("    -w  --buf_count      Number of buffers used\n");
     printf("    -R, --force-register Force registration of buffers\n");
+    printf("    -M, --millionbps     Output in Million B/s instead of MB/s\n");
     printf("    -V, --verbose        Print verbose output\n");
 }
 
@@ -167,6 +169,9 @@ na_test_parse_options(int argc, char *argv[], struct na_test_info *na_test_info)
             case 'z': /* max buffer size */
                 na_test_info->buf_size_max = (size_t) atol(na_test_opt_arg_g);
                 break;
+            case 'w': /* buffer count */
+                na_test_info->buf_count = (size_t) atol(na_test_opt_arg_g);
+                break;
             case 'Z': /* msg size */
                 na_test_info->max_msg_size = (size_t) atol(na_test_opt_arg_g);
                 break;
@@ -178,6 +183,9 @@ na_test_parse_options(int argc, char *argv[], struct na_test_info *na_test_info)
                 break;
             case 'V': /* verbose */
                 na_test_info->verbose = true;
+                break;
+            case 'M': /* OSU-style output Million Bytes/s */
+                na_test_info->millionbps = true;
                 break;
             default:
                 break;

--- a/Testing/na/na_test.h
+++ b/Testing/na/na_test.h
@@ -38,6 +38,7 @@ struct na_test_info {
     size_t max_msg_size;     /* Max msg size */
     size_t buf_size_min;     /* Min buffer size */
     size_t buf_size_max;     /* Max buffer size */
+    size_t buf_count;        /* Buffer count */
     bool verbose;            /* Verbose mode */
     int max_number_of_peers; /* Max number of peers */
 #ifdef HG_TEST_HAS_PARALLEL
@@ -50,6 +51,7 @@ struct na_test_info {
     bool use_threads;    /* Use threads */
     bool force_register; /* Force registration each iteration */
     bool verify;         /* Verify data */
+    bool millionbps;     /* OSU-style of output in Million Bytes/s */
 };
 
 /*****************/

--- a/Testing/na/na_test_getopt.c
+++ b/Testing/na/na_test_getopt.c
@@ -13,7 +13,7 @@
 
 int na_test_opt_ind_g = 1;            /* token pointer */
 const char *na_test_opt_arg_g = NULL; /* flag argument (or value) */
-const char *na_test_short_opt_g = "hc:d:p:H:P:LsSk:l:bC:X:VaZ:y:z:x:mt:BRv";
+const char *na_test_short_opt_g = "hc:d:p:H:P:LsSk:l:bC:X:VaZ:y:z:w:x:mt:BRvM";
 /* clang-format off */
 const struct na_test_opt na_test_opt_g[] = {
     {"help", no_arg, 'h'},
@@ -35,12 +35,14 @@ const struct na_test_opt na_test_opt_g[] = {
     {"msg_size", require_arg, 'Z'},
     {"buf_size_min", require_arg, 'y'},
     {"buf_size_max", require_arg, 'z'},
+    {"buf_count", require_arg, 'w'},
     {"handle", require_arg, 'x'},
     {"memory", no_arg, 'm'},
     {"threads", require_arg, 't'},
     {"bidirectional", no_arg, 'B'},
     {"force-register", no_arg, 'R'},
     {"verify", no_arg, 'v'},
+    {"millionbps", no_arg, 'M'},
     {NULL, 0, '\0'} /* Must add this at the end */
 };
 /* clang-format on */

--- a/Testing/na/na_test_perf.c
+++ b/Testing/na/na_test_perf.c
@@ -6,12 +6,26 @@
 
 #include "na_test_perf.h"
 
+#include "mercury_mem.h"
+
 /****************/
 /* Local Macros */
 /****************/
 
 /* Default RMA size max if not specified */
-#define NA_TEST_RMA_SIZE_MAX (1 << 24)
+#define NA_TEST_PERF_RMA_SIZE_MAX (1 << 24)
+
+/* Default RMA count if not specified */
+#define NA_TEST_PERF_RMA_COUNT 64
+
+#define STRING(s)  #s
+#define XSTRING(s) STRING(s)
+#define VERSION_NAME                                                           \
+    XSTRING(NA_VERSION_MAJOR)                                                  \
+    "." XSTRING(NA_VERSION_MINOR) "." XSTRING(NA_VERSION_PATCH)
+
+#define NDIGITS 2
+#define NWIDTH  27
 
 /************************************/
 /* Local Type and Struct Definition */
@@ -89,11 +103,26 @@ na_test_perf_request_complete(const struct na_cb_info *na_cb_info)
 }
 
 /*---------------------------------------------------------------------------*/
+int
+na_test_perf_rma_request_complete(const struct na_cb_info *na_cb_info)
+{
+    struct na_test_perf_rma_info *info =
+        (struct na_test_perf_rma_info *) na_cb_info->arg;
+
+    if ((++info->complete_count) == info->expected_count)
+        hg_request_complete(info->request);
+
+    return NA_SUCCESS;
+}
+
+/*---------------------------------------------------------------------------*/
 na_return_t
 na_test_perf_init(
     int argc, char *argv[], bool listen, struct na_test_perf_info *info)
 {
+    size_t page_size = (size_t) hg_mem_get_page_size();
     na_return_t ret;
+    size_t i;
 
     /* Initialize the interface */
     memset(info, 0, sizeof(*info));
@@ -156,7 +185,11 @@ na_test_perf_init(
 
     info->rma_size_max = info->na_test_info.buf_size_max;
     if (info->rma_size_max == 0)
-        info->rma_size_max = NA_TEST_RMA_SIZE_MAX;
+        info->rma_size_max = NA_TEST_PERF_RMA_SIZE_MAX;
+
+    info->rma_count = info->na_test_info.buf_count;
+    if (info->rma_count == 0)
+        info->rma_count = NA_TEST_PERF_RMA_COUNT;
 
     /* Check that sizes are power of 2 */
     NA_TEST_CHECK_ERROR(!powerof2(info->rma_size_min), error, ret,
@@ -190,14 +223,16 @@ na_test_perf_init(
         NA_Error_to_string(ret));
 
     /* Prepare RMA buf */
-    info->rma_buf = malloc(info->rma_size_max);
+    info->rma_buf =
+        hg_mem_aligned_alloc(page_size, info->rma_size_max * info->rma_count);
     NA_TEST_CHECK_ERROR(info->rma_buf == NULL, error, ret, NA_NOMEM,
-        "NA_Msg_buf_alloc() failed");
-    memset(info->rma_buf, 0, info->rma_size_max);
+        "hg_mem_aligned_alloc(%zu, %zu) failed", page_size, info->rma_size_max);
+    memset(info->rma_buf, 0, info->rma_size_max * info->rma_count);
 
     if (!info->na_test_info.force_register) {
         ret = NA_Mem_handle_create(info->na_class, info->rma_buf,
-            info->rma_size_max, NA_MEM_READWRITE, &info->local_handle);
+            info->rma_size_max * info->rma_count, NA_MEM_READWRITE,
+            &info->local_handle);
         NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Mem_handle_create() failed (%s)",
             NA_Error_to_string(ret));
 
@@ -208,13 +243,16 @@ na_test_perf_init(
     }
 
     if (info->na_test_info.verify) {
-        info->verify_buf = malloc(info->rma_size_max);
+        info->verify_buf = hg_mem_aligned_alloc(
+            page_size, info->rma_size_max * info->rma_count);
         NA_TEST_CHECK_ERROR(info->verify_buf == NULL, error, ret, NA_NOMEM,
-            "NA_Msg_buf_alloc() failed");
-        memset(info->verify_buf, 0, info->rma_size_max);
+            "hg_mem_aligned_alloc(%zu, %zu) failed", page_size,
+            info->rma_size_max);
+        memset(info->verify_buf, 0, info->rma_size_max * info->rma_count);
 
         ret = NA_Mem_handle_create(info->na_class, info->verify_buf,
-            info->rma_size_max, NA_MEM_READWRITE, &info->verify_handle);
+            info->rma_size_max * info->rma_count, NA_MEM_READWRITE,
+            &info->verify_handle);
         NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Mem_handle_create() failed (%s)",
             NA_Error_to_string(ret));
 
@@ -224,21 +262,32 @@ na_test_perf_init(
             NA_Error_to_string(ret));
     }
 
-    /* Create operation IDs */
+    /* Create msg operation IDs */
     info->msg_unexp_op_id = NA_Op_create(info->na_class);
     NA_TEST_CHECK_ERROR(info->msg_unexp_op_id == NULL, error, ret, NA_NOMEM,
         "NA_Op_create() failed");
     info->msg_exp_op_id = NA_Op_create(info->na_class);
     NA_TEST_CHECK_ERROR(info->msg_exp_op_id == NULL, error, ret, NA_NOMEM,
         "NA_Op_create() failed");
-    info->rma_op_id = NA_Op_create(info->na_class);
-    NA_TEST_CHECK_ERROR(
-        info->rma_op_id == NULL, error, ret, NA_NOMEM, "NA_Op_create() failed");
 
     /* Create request */
     info->request = hg_request_create(info->request_class);
     NA_TEST_CHECK_ERROR(info->request == NULL, error, ret, NA_NOMEM,
         "hg_request_create() failed");
+
+    /* Create RMA operation IDs */
+    info->rma_op_ids =
+        (na_op_id_t **) malloc(sizeof(na_op_id_t *) * info->rma_count);
+    NA_TEST_CHECK_ERROR(info->rma_op_ids == NULL, error, ret, NA_NOMEM,
+        "Could not allocate RMA op IDs");
+    for (i = 0; i < info->rma_count; i++)
+        info->rma_op_ids[i] = NULL;
+
+    for (i = 0; i < info->rma_count; i++) {
+        info->rma_op_ids[i] = NA_Op_create(info->na_class);
+        NA_TEST_CHECK_ERROR(info->rma_op_ids[i] == NULL, error, ret, NA_NOMEM,
+            "NA_Op_create() failed");
+    }
 
     return NA_SUCCESS;
 
@@ -257,8 +306,14 @@ na_test_perf_cleanup(struct na_test_perf_info *info)
     if (info->msg_exp_op_id != NULL)
         NA_Op_destroy(info->na_class, info->msg_exp_op_id);
 
-    if (info->rma_op_id != NULL)
-        NA_Op_destroy(info->na_class, info->rma_op_id);
+    if (info->rma_op_ids != NULL) {
+        size_t i;
+
+        for (i = 0; i < info->rma_count; i++)
+            if (info->rma_op_ids[i] != NULL)
+                NA_Op_destroy(info->na_class, info->rma_op_ids[i]);
+        free(info->rma_op_ids);
+    }
 
     if (info->msg_unexp_buf != NULL)
         NA_Msg_buf_free(
@@ -277,8 +332,8 @@ na_test_perf_cleanup(struct na_test_perf_info *info)
     }
     if (info->remote_handle != NA_MEM_HANDLE_NULL)
         NA_Mem_handle_free(info->na_class, info->remote_handle);
-    free(info->rma_buf);
-    free(info->verify_buf);
+    hg_mem_aligned_free(info->rma_buf);
+    hg_mem_aligned_free(info->verify_buf);
 
     if (info->target_addr != NA_ADDR_NULL)
         NA_Addr_free(info->na_class, info->target_addr);
@@ -299,6 +354,80 @@ na_test_perf_cleanup(struct na_test_perf_info *info)
         NA_Context_destroy(info->na_class, info->context);
 
     NA_Test_finalize(&info->na_test_info);
+}
+
+/*---------------------------------------------------------------------------*/
+void
+na_test_perf_print_header_lat(const struct na_test_perf_info *info,
+    const char *benchmark, size_t min_size)
+{
+    fprintf(stdout, "# %s v%s\n", benchmark, VERSION_NAME);
+    fprintf(stdout, "# Loop %d times from size %zu to %zu byte(s)\n",
+        info->na_test_info.loop, min_size, info->msg_unexp_size_max);
+    if (info->na_test_info.verify)
+        fprintf(stdout, "# WARNING verifying data, output will be slower\n");
+    fprintf(stdout, "%-*s%*s\n", 10, "# Size", NWIDTH, "Avg Lat (us)");
+    fflush(stdout);
+}
+
+/*---------------------------------------------------------------------------*/
+void
+na_test_perf_print_lat(
+    const struct na_test_perf_info *info, size_t buf_size, hg_time_t t)
+{
+    double msg_lat;
+    size_t loop = (size_t) info->na_test_info.loop,
+           mpi_comm_size = (size_t) info->na_test_info.mpi_comm_size;
+
+    msg_lat = hg_time_to_double(t) * 1e6 / (double) (loop * 2 * mpi_comm_size);
+
+    printf("%-*zu%*.*f\n", 10, buf_size, NWIDTH, NDIGITS, msg_lat);
+}
+
+/*---------------------------------------------------------------------------*/
+void
+na_test_perf_print_header_bw(
+    const struct na_test_perf_info *info, const char *benchmark)
+{
+    printf("# %s v%s\n", benchmark, VERSION_NAME);
+    printf("# Loop %d times from size %zu to %zu byte(s), RMA count (%zu)\n",
+        info->na_test_info.loop, info->rma_size_min, info->rma_size_max,
+        info->rma_count);
+    if (info->na_test_info.verify)
+        printf("# WARNING verifying data, output will be slower\n");
+    if (info->na_test_info.force_register)
+        printf("# WARNING forcing registration on every iteration\n");
+    if (info->na_test_info.millionbps)
+        printf("%-*s%*s%*s\n", 10, "# Size", NWIDTH,
+            "Bandwidth (Million Bytes/s)", NWIDTH, "Time (us)");
+    else
+        printf("%-*s%*s%*s\n", 10, "# Size", NWIDTH, "Bandwidth (MB/s)", NWIDTH,
+            "Time (us)");
+    fflush(stdout);
+}
+
+/*---------------------------------------------------------------------------*/
+void
+na_test_perf_print_bw(
+    const struct na_test_perf_info *info, size_t buf_size, hg_time_t t)
+{
+    size_t loop = (size_t) info->na_test_info.loop,
+           mpi_comm_size = (size_t) info->na_test_info.mpi_comm_size,
+           buf_count = (size_t) info->rma_count;
+    double avg_time, avg_bw;
+
+    avg_time = hg_time_to_double(t) * 1e6 /
+               (double) (loop * mpi_comm_size * buf_count);
+    avg_bw = (double) (buf_size * loop * mpi_comm_size * buf_count) /
+             hg_time_to_double(t);
+
+    if (info->na_test_info.millionbps)
+        avg_bw /= 1e6; /* Million Bytes / s, matches OSU benchmarks */
+    else
+        avg_bw /= (1024 * 1024); /* MB/s */
+
+    printf("%-*zu%*.*f%*.*f\n", 10, buf_size, NWIDTH, NDIGITS, avg_bw, NWIDTH,
+        NDIGITS, avg_time);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/Testing/na/na_test_perf.h
+++ b/Testing/na/na_test_perf.h
@@ -39,37 +39,39 @@ struct na_test_perf_info {
     na_mem_handle_t local_handle;      /* Local handle */
     na_mem_handle_t remote_handle;     /* Remote handle */
     na_mem_handle_t verify_handle;     /* Local handle to verify buffer */
-    na_op_id_t *rma_op_id;             /* RMA op ID */
+    na_op_id_t **rma_op_ids;           /* RMA op IDs */
     size_t msg_unexp_header_size;      /* Header size */
     size_t msg_exp_header_size;        /* Header size */
     size_t msg_unexp_size_max;         /* Max buffer size */
     size_t msg_exp_size_max;           /* Max buffer size */
     size_t rma_size_min;               /* Min buffer size */
     size_t rma_size_max;               /* Max buffer size */
+    size_t rma_count;                  /* Buffer count */
     hg_request_t *request;             /* Request */
     int poll_fd;                       /* Poll fd */
+};
+
+struct na_test_perf_rma_info {
+    int32_t expected_count; /* Expected count */
+    int32_t complete_count; /* Completed count */
+    hg_request_t *request;  /* Request */
 };
 
 /*****************/
 /* Public Macros */
 /*****************/
 
-#define STRING(s)  #s
-#define XSTRING(s) STRING(s)
-#define VERSION_NAME                                                           \
-    XSTRING(NA_VERSION_MAJOR)                                                  \
-    "." XSTRING(NA_VERSION_MINOR) "." XSTRING(NA_VERSION_PATCH)
-
-#define SMALL_SKIP 1000
-
-#define NDIGITS 2
-#define NWIDTH  15
-
 #define NA_TEST_PERF_TAG_LAT_INIT 0
 #define NA_TEST_PERF_TAG_LAT      1
 #define NA_TEST_PERF_TAG_PUT      10
 #define NA_TEST_PERF_TAG_GET      20
 #define NA_TEST_PERF_TAG_DONE     111
+
+#define NA_TEST_PERF_LAT_SKIP_SMALL 100
+#define NA_TEST_PERF_LAT_SKIP_LARGE 10
+#define NA_TEST_PERF_BW_SKIP_SMALL  10
+#define NA_TEST_PERF_BW_SKIP_LARGE  2
+#define NA_TEST_PERF_LARGE_SIZE     8192
 
 /*********************/
 /* Public Prototypes */
@@ -89,12 +91,31 @@ na_test_perf_request_trigger(
 int
 na_test_perf_request_complete(const struct na_cb_info *na_cb_info);
 
+int
+na_test_perf_rma_request_complete(const struct na_cb_info *na_cb_info);
+
 na_return_t
 na_test_perf_init(
     int argc, char *argv[], bool listen, struct na_test_perf_info *info);
 
 void
 na_test_perf_cleanup(struct na_test_perf_info *info);
+
+void
+na_test_perf_print_header_lat(const struct na_test_perf_info *info,
+    const char *benchmark, size_t min_size);
+
+void
+na_test_perf_print_lat(
+    const struct na_test_perf_info *info, size_t buf_size, hg_time_t t);
+
+void
+na_test_perf_print_header_bw(
+    const struct na_test_perf_info *info, const char *benchmark);
+
+void
+na_test_perf_print_bw(
+    const struct na_test_perf_info *info, size_t buf_size, hg_time_t t);
 
 void
 na_test_perf_init_data(void *buf, size_t buf_size, size_t header_size);

--- a/Testing/na/test_bw_get.c
+++ b/Testing/na/test_bw_get.c
@@ -20,7 +20,7 @@
 /********************/
 
 static na_return_t
-na_test_perf_run(struct na_test_perf_info *info, size_t buf_size);
+na_test_perf_run(struct na_test_perf_info *info, size_t buf_size, size_t skip);
 
 /*******************/
 /* Local Variables */
@@ -28,66 +28,33 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size);
 
 /*---------------------------------------------------------------------------*/
 static na_return_t
-na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
+na_test_perf_run(struct na_test_perf_info *info, size_t buf_size, size_t skip)
 {
-    size_t loop = (size_t) info->na_test_info.loop;
-    unsigned int mpi_comm_size =
-        (unsigned int) info->na_test_info.mpi_comm_size;
-    int mpi_comm_rank = info->na_test_info.mpi_comm_rank;
-    size_t iter_cur;
-    hg_time_t time_add = hg_time_from_ms(0);
     hg_time_t t1, t2;
-    double avg_time, avg_bw;
     na_return_t ret;
-    size_t i;
-
-    /* Warm up */
-    for (i = 0; i < SMALL_SKIP; i++) {
-        hg_request_reset(info->request);
-
-        if (info->na_test_info.force_register) {
-            ret = NA_Mem_handle_create(info->na_class, info->rma_buf,
-                info->rma_size_max, NA_MEM_READ_ONLY, &info->local_handle);
-            NA_TEST_CHECK_NA_ERROR(error, ret,
-                "NA_Mem_handle_create() failed (%s)", NA_Error_to_string(ret));
-
-            ret = NA_Mem_register(
-                info->na_class, info->local_handle, NA_MEM_TYPE_HOST, 0);
-            NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Mem_register() failed (%s)",
-                NA_Error_to_string(ret));
-        }
-
-        /* Post get */
-        ret =
-            NA_Get(info->na_class, info->context, na_test_perf_request_complete,
-                info->request, info->local_handle, 0, info->remote_handle, 0,
-                buf_size, info->target_addr, 0, info->rma_op_id);
-        NA_TEST_CHECK_NA_ERROR(
-            error, ret, "NA_Get() failed (%s)", NA_Error_to_string(ret));
-
-        hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
-
-        if (info->na_test_info.force_register) {
-            NA_Mem_deregister(info->na_class, info->local_handle);
-            NA_Mem_handle_free(info->na_class, info->local_handle);
-            info->local_handle = NA_MEM_HANDLE_NULL;
-        }
-    }
+    size_t i, j;
 
     if (info->na_test_info.mpi_comm_size > 1)
         NA_Test_barrier(&info->na_test_info);
 
-    hg_time_get_current(&t1);
-
     /* Actual benchmark */
-    for (iter_cur = 0; iter_cur < loop; iter_cur++) {
+    for (i = 0; i < skip + (size_t) info->na_test_info.loop; i++) {
+        struct na_test_perf_rma_info rma_info = {.request = info->request,
+            .complete_count = 0,
+            .expected_count = (int32_t) info->rma_count};
+
+        if (i == skip)
+            hg_time_get_current(&t1);
+
         hg_request_reset(info->request);
+
         if (info->na_test_info.verify)
             memset(info->rma_buf, 0, buf_size);
 
         if (info->na_test_info.force_register) {
             ret = NA_Mem_handle_create(info->na_class, info->rma_buf,
-                info->rma_size_max, NA_MEM_READWRITE, &info->local_handle);
+                info->rma_size_max * info->rma_count, NA_MEM_READWRITE,
+                &info->local_handle);
             NA_TEST_CHECK_NA_ERROR(error, ret,
                 "NA_Mem_handle_create() failed (%s)", NA_Error_to_string(ret));
 
@@ -97,21 +64,28 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
                 NA_Error_to_string(ret));
         }
 
-        /* Post get */
-        ret =
-            NA_Get(info->na_class, info->context, na_test_perf_request_complete,
-                info->request, info->local_handle, 0, info->remote_handle, 0,
-                buf_size, info->target_addr, 0, info->rma_op_id);
-        NA_TEST_CHECK_NA_ERROR(
-            error, ret, "NA_Get() failed (%s)", NA_Error_to_string(ret));
+        /* Post gets */
+        for (j = 0; j < info->rma_count; j++) {
+            ret = NA_Get(info->na_class, info->context,
+                na_test_perf_rma_request_complete, &rma_info,
+                info->local_handle, j * info->rma_size_max, info->remote_handle,
+                j * info->rma_size_max, buf_size, info->target_addr, 0,
+                info->rma_op_ids[j]);
+            NA_TEST_CHECK_NA_ERROR(
+                error, ret, "NA_Get() failed (%s)", NA_Error_to_string(ret));
+        }
 
         hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
 
         if (info->na_test_info.verify) {
-            ret = na_test_perf_verify_data(info->rma_buf, buf_size, 0);
-            NA_TEST_CHECK_NA_ERROR(error, ret,
-                "na_test_perf_verify_data() failed (%s)",
-                NA_Error_to_string(ret));
+            for (j = 0; j < info->rma_count; j++) {
+                ret = na_test_perf_verify_data(
+                    (const char *) info->rma_buf + j * info->rma_size_max,
+                    buf_size, 0);
+                NA_TEST_CHECK_NA_ERROR(error, ret,
+                    "na_test_perf_verify_data() failed (%s)",
+                    NA_Error_to_string(ret));
+            }
         }
 
         if (info->na_test_info.force_register) {
@@ -125,19 +99,9 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
         NA_Test_barrier(&info->na_test_info);
 
     hg_time_get_current(&t2);
-    time_add = hg_time_subtract(t2, t1);
 
-    avg_time =
-        hg_time_to_double(time_add) * 1.0e6 / (double) (loop * mpi_comm_size);
-    avg_bw = (double) (buf_size * loop * mpi_comm_size) /
-             (hg_time_to_double(time_add) * 1024 * 1024);
-
-    if (mpi_comm_rank == 0)
-        fprintf(stdout, "%-*zu%*.*f%*.*f", 10, buf_size, NWIDTH, NDIGITS,
-            avg_bw, NWIDTH, NDIGITS, avg_time);
-
-    if (mpi_comm_rank == 0)
-        fprintf(stdout, "\n");
+    if (info->na_test_info.mpi_comm_rank == 0)
+        na_test_perf_print_bw(info, buf_size, hg_time_subtract(t2, t1));
 
     return NA_SUCCESS;
 
@@ -165,24 +129,14 @@ main(int argc, char *argv[])
         NA_Error_to_string(na_ret));
 
     /* Header info */
-    if (info.na_test_info.mpi_comm_rank == 0) {
-        fprintf(stdout, "# %s v%s\n", BENCHMARK_NAME, VERSION_NAME);
-        fprintf(stdout, "# Loop %d times from size %zu to %zu byte(s)\n",
-            info.na_test_info.loop, info.rma_size_min, info.rma_size_max);
-        if (info.na_test_info.verify)
-            fprintf(
-                stdout, "# WARNING verifying data, output will be slower\n");
-        if (info.na_test_info.force_register)
-            fprintf(
-                stdout, "# WARNING forcing registration on every iteration\n");
-        fprintf(stdout, "%-*s%*s%*s\n", 10, "# Size", NWIDTH,
-            "Bandwidth (MB/s)", NWIDTH, "Time (us)");
-        fflush(stdout);
-    }
+    if (info.na_test_info.mpi_comm_rank == 0)
+        na_test_perf_print_header_bw(&info, BENCHMARK_NAME);
 
     /* Msg with different sizes */
     for (size = info.rma_size_min; size <= info.rma_size_max; size *= 2) {
-        na_ret = na_test_perf_run(&info, size);
+        na_ret = na_test_perf_run(&info, size,
+            (size > NA_TEST_PERF_LARGE_SIZE) ? NA_TEST_PERF_BW_SKIP_LARGE
+                                             : NA_TEST_PERF_BW_SKIP_SMALL);
         NA_TEST_CHECK_NA_ERROR(error, na_ret,
             "na_test_perf_run(%zu) failed (%s)", size,
             NA_Error_to_string(na_ret));

--- a/Testing/na/test_bw_put.c
+++ b/Testing/na/test_bw_put.c
@@ -20,7 +20,7 @@
 /********************/
 
 static na_return_t
-na_test_perf_run(struct na_test_perf_info *info, size_t buf_size);
+na_test_perf_run(struct na_test_perf_info *info, size_t buf_size, size_t skip);
 
 /*******************/
 /* Local Variables */
@@ -28,66 +28,33 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size);
 
 /*---------------------------------------------------------------------------*/
 static na_return_t
-na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
+na_test_perf_run(struct na_test_perf_info *info, size_t buf_size, size_t skip)
 {
-    size_t loop = (size_t) info->na_test_info.loop;
-    unsigned int mpi_comm_size =
-        (unsigned int) info->na_test_info.mpi_comm_size;
-    int mpi_comm_rank = info->na_test_info.mpi_comm_rank;
-    size_t iter_cur;
-    hg_time_t time_add = hg_time_from_ms(0);
     hg_time_t t1, t2;
-    double avg_time, avg_bw;
     na_return_t ret;
-    size_t i;
-
-    /* Warm up */
-    for (i = 0; i < SMALL_SKIP; i++) {
-        hg_request_reset(info->request);
-
-        if (info->na_test_info.force_register) {
-            ret = NA_Mem_handle_create(info->na_class, info->rma_buf,
-                info->rma_size_max, NA_MEM_READ_ONLY, &info->local_handle);
-            NA_TEST_CHECK_NA_ERROR(error, ret,
-                "NA_Mem_handle_create() failed (%s)", NA_Error_to_string(ret));
-
-            ret = NA_Mem_register(
-                info->na_class, info->local_handle, NA_MEM_TYPE_HOST, 0);
-            NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Mem_register() failed (%s)",
-                NA_Error_to_string(ret));
-        }
-
-        /* Post put */
-        ret =
-            NA_Put(info->na_class, info->context, na_test_perf_request_complete,
-                info->request, info->local_handle, 0, info->remote_handle, 0,
-                buf_size, info->target_addr, 0, info->rma_op_id);
-        NA_TEST_CHECK_NA_ERROR(
-            error, ret, "NA_Put() failed (%s)", NA_Error_to_string(ret));
-
-        hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
-
-        if (info->na_test_info.force_register) {
-            NA_Mem_deregister(info->na_class, info->local_handle);
-            NA_Mem_handle_free(info->na_class, info->local_handle);
-            info->local_handle = NA_MEM_HANDLE_NULL;
-        }
-    }
+    size_t i, j;
 
     if (info->na_test_info.mpi_comm_size > 1)
         NA_Test_barrier(&info->na_test_info);
 
-    hg_time_get_current(&t1);
-
     /* Actual benchmark */
-    for (iter_cur = 0; iter_cur < loop; iter_cur++) {
+    for (i = 0; i < skip + (size_t) info->na_test_info.loop; i++) {
+        struct na_test_perf_rma_info rma_info = {.request = info->request,
+            .complete_count = 0,
+            .expected_count = (int32_t) info->rma_count};
+
+        if (i == skip)
+            hg_time_get_current(&t1);
+
         hg_request_reset(info->request);
+
         if (info->na_test_info.verify)
             memset(info->verify_buf, 0, buf_size);
 
         if (info->na_test_info.force_register) {
             ret = NA_Mem_handle_create(info->na_class, info->rma_buf,
-                info->rma_size_max, NA_MEM_READ_ONLY, &info->local_handle);
+                info->rma_size_max * info->rma_count, NA_MEM_READ_ONLY,
+                &info->local_handle);
             NA_TEST_CHECK_NA_ERROR(error, ret,
                 "NA_Mem_handle_create() failed (%s)", NA_Error_to_string(ret));
 
@@ -97,33 +64,44 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
                 NA_Error_to_string(ret));
         }
 
-        /* Post put */
-        ret =
-            NA_Put(info->na_class, info->context, na_test_perf_request_complete,
-                info->request, info->local_handle, 0, info->remote_handle, 0,
-                buf_size, info->target_addr, 0, info->rma_op_id);
-        NA_TEST_CHECK_NA_ERROR(
-            error, ret, "NA_Put() failed (%s)", NA_Error_to_string(ret));
+        /* Post puts */
+        for (j = 0; j < info->rma_count; j++) {
+            ret = NA_Put(info->na_class, info->context,
+                na_test_perf_rma_request_complete, &rma_info,
+                info->local_handle, j * info->rma_size_max, info->remote_handle,
+                j * info->rma_size_max, buf_size, info->target_addr, 0,
+                info->rma_op_ids[j]);
+            NA_TEST_CHECK_NA_ERROR(
+                error, ret, "NA_Put() failed (%s)", NA_Error_to_string(ret));
+        }
 
         hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
 
         if (info->na_test_info.verify) {
+            rma_info.complete_count = 0;
             hg_request_reset(info->request);
 
-            /* Post get */
-            ret = NA_Get(info->na_class, info->context,
-                na_test_perf_request_complete, info->request,
-                info->verify_handle, 0, info->remote_handle, 0, buf_size,
-                info->target_addr, 0, info->rma_op_id);
-            NA_TEST_CHECK_NA_ERROR(
-                error, ret, "NA_Get() failed (%s)", NA_Error_to_string(ret));
+            /* Post gets */
+            for (j = 0; j < info->rma_count; j++) {
+                ret = NA_Get(info->na_class, info->context,
+                    na_test_perf_rma_request_complete, &rma_info,
+                    info->verify_handle, j * info->rma_size_max,
+                    info->remote_handle, j * info->rma_size_max, buf_size,
+                    info->target_addr, 0, info->rma_op_ids[j]);
+                NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Get() failed (%s)",
+                    NA_Error_to_string(ret));
+            }
 
             hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
 
-            ret = na_test_perf_verify_data(info->verify_buf, buf_size, 0);
-            NA_TEST_CHECK_NA_ERROR(error, ret,
-                "na_test_perf_verify_data() failed (%s)",
-                NA_Error_to_string(ret));
+            for (j = 0; j < info->rma_count; j++) {
+                ret = na_test_perf_verify_data(
+                    (const char *) info->verify_buf + j * info->rma_size_max,
+                    buf_size, 0);
+                NA_TEST_CHECK_NA_ERROR(error, ret,
+                    "na_test_perf_verify_data() failed (%s)",
+                    NA_Error_to_string(ret));
+            }
         }
 
         if (info->na_test_info.force_register) {
@@ -137,19 +115,9 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
         NA_Test_barrier(&info->na_test_info);
 
     hg_time_get_current(&t2);
-    time_add = hg_time_subtract(t2, t1);
 
-    avg_time =
-        hg_time_to_double(time_add) * 1.0e6 / (double) (loop * mpi_comm_size);
-    avg_bw = (double) (buf_size * loop * mpi_comm_size) /
-             (hg_time_to_double(time_add) * 1024 * 1024);
-
-    if (mpi_comm_rank == 0)
-        fprintf(stdout, "%-*zu%*.*f%*.*f", 10, buf_size, NWIDTH, NDIGITS,
-            avg_bw, NWIDTH, NDIGITS, avg_time);
-
-    if (mpi_comm_rank == 0)
-        fprintf(stdout, "\n");
+    if (info->na_test_info.mpi_comm_rank == 0)
+        na_test_perf_print_bw(info, buf_size, hg_time_subtract(t2, t1));
 
     return NA_SUCCESS;
 
@@ -162,7 +130,7 @@ int
 main(int argc, char *argv[])
 {
     struct na_test_perf_info info;
-    size_t size;
+    size_t size, i;
     na_return_t na_ret;
 
     /* Initialize the interface */
@@ -170,8 +138,10 @@ main(int argc, char *argv[])
     NA_TEST_CHECK_NA_ERROR(error, na_ret, "na_test_perf_init() failed (%s)",
         NA_Error_to_string(na_ret));
 
-    /* init data */
-    na_test_perf_init_data(info.rma_buf, info.rma_size_max, 0);
+    /* Init data */
+    for (i = 0; i < info.rma_count; i++)
+        na_test_perf_init_data((char *) info.rma_buf + i * info.rma_size_max,
+            info.rma_size_max, 0);
 
     /* Retrieve server memory handle */
     na_ret = na_test_perf_mem_handle_recv(&info, NA_TEST_PERF_TAG_PUT);
@@ -180,24 +150,14 @@ main(int argc, char *argv[])
         NA_Error_to_string(na_ret));
 
     /* Header info */
-    if (info.na_test_info.mpi_comm_rank == 0) {
-        fprintf(stdout, "# %s v%s\n", BENCHMARK_NAME, VERSION_NAME);
-        fprintf(stdout, "# Loop %d times from size %zu to %zu byte(s)\n",
-            info.na_test_info.loop, info.rma_size_min, info.rma_size_max);
-        if (info.na_test_info.verify)
-            fprintf(
-                stdout, "# WARNING verifying data, output will be slower\n");
-        if (info.na_test_info.force_register)
-            fprintf(
-                stdout, "# WARNING forcing registration on every iteration\n");
-        fprintf(stdout, "%-*s%*s%*s\n", 10, "# Size", NWIDTH,
-            "Bandwidth (MB/s)", NWIDTH, "Time (us)");
-        fflush(stdout);
-    }
+    if (info.na_test_info.mpi_comm_rank == 0)
+        na_test_perf_print_header_bw(&info, BENCHMARK_NAME);
 
     /* Msg with different sizes */
     for (size = info.rma_size_min; size <= info.rma_size_max; size *= 2) {
-        na_ret = na_test_perf_run(&info, size);
+        na_ret = na_test_perf_run(&info, size,
+            (size > NA_TEST_PERF_LARGE_SIZE) ? NA_TEST_PERF_BW_SKIP_LARGE
+                                             : NA_TEST_PERF_BW_SKIP_SMALL);
         NA_TEST_CHECK_NA_ERROR(error, na_ret,
             "na_test_perf_run(%zu) failed (%s)", size,
             NA_Error_to_string(na_ret));

--- a/Testing/na/test_lat.c
+++ b/Testing/na/test_lat.c
@@ -20,58 +20,54 @@
 /********************/
 
 static na_return_t
-na_test_perf_run(struct na_test_perf_info *info, size_t buf_size);
+na_test_perf_run(struct na_test_perf_info *info, size_t buf_size, size_t skip);
 
 /*******************/
 /* Local Variables */
 /*******************/
 
+static na_return_t
+na_test_perf_send_init(struct na_test_perf_info *info)
+{
+    na_return_t ret;
+
+    /* Reset */
+    hg_request_reset(info->request);
+
+    /* Post one-way msg send */
+    ret = NA_Msg_send_unexpected(info->na_class, info->context,
+        na_test_perf_request_complete, info->request, info->msg_unexp_buf,
+        info->msg_unexp_header_size, info->msg_unexp_data, info->target_addr, 0,
+        NA_TEST_PERF_TAG_LAT_INIT, info->msg_unexp_op_id);
+    NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Msg_send_unexpected() failed (%s)",
+        NA_Error_to_string(ret));
+
+    hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
+
+    return NA_SUCCESS;
+
+error:
+    return ret;
+}
+
 /*---------------------------------------------------------------------------*/
 static na_return_t
-na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
+na_test_perf_run(struct na_test_perf_info *info, size_t buf_size, size_t skip)
 {
-    size_t loop = (size_t) info->na_test_info.loop;
-    unsigned int mpi_comm_size =
-        (unsigned int) info->na_test_info.mpi_comm_size;
-    int mpi_comm_rank = info->na_test_info.mpi_comm_rank;
-    size_t iter_cur;
-    hg_time_t time_add = hg_time_from_ms(0);
     hg_time_t t1, t2;
-    double msg_lat;
     na_return_t ret;
     size_t i;
-
-    /* Warm up */
-    for (i = 0; i < SMALL_SKIP; i++) {
-        hg_request_reset(info->request);
-
-        /* Post recv */
-        ret = NA_Msg_recv_expected(info->na_class, info->context,
-            na_test_perf_request_complete, info->request, info->msg_exp_buf,
-            buf_size, info->msg_exp_data, info->target_addr, 0,
-            NA_TEST_PERF_TAG_LAT_INIT, info->msg_exp_op_id);
-        NA_TEST_CHECK_NA_ERROR(error, ret, "NA_Msg_recv_expected() failed (%s)",
-            NA_Error_to_string(ret));
-
-        /* Post send */
-        ret = NA_Msg_send_unexpected(info->na_class, info->context, NULL, NULL,
-            info->msg_unexp_buf, buf_size, info->msg_unexp_data,
-            info->target_addr, 0, NA_TEST_PERF_TAG_LAT_INIT,
-            info->msg_unexp_op_id);
-        NA_TEST_CHECK_NA_ERROR(error, ret,
-            "NA_Msg_send_unexpected() failed (%s)", NA_Error_to_string(ret));
-
-        hg_request_wait(info->request, NA_MAX_IDLE_TIME, NULL);
-    }
 
     if (info->na_test_info.mpi_comm_size > 1)
         NA_Test_barrier(&info->na_test_info);
 
-    hg_time_get_current(&t1);
-
     /* Actual benchmark */
-    for (iter_cur = 0; iter_cur < loop; iter_cur++) {
+    for (i = 0; i < skip + (size_t) info->na_test_info.loop; i++) {
+        if (i == skip)
+            hg_time_get_current(&t1);
+
         hg_request_reset(info->request);
+
         if (info->na_test_info.verify) {
             memset(info->msg_exp_buf, 0, buf_size);
 
@@ -112,16 +108,9 @@ na_test_perf_run(struct na_test_perf_info *info, size_t buf_size)
         NA_Test_barrier(&info->na_test_info);
 
     hg_time_get_current(&t2);
-    time_add = hg_time_subtract(t2, t1);
 
-    msg_lat = hg_time_to_double(time_add) * 1.0e6 /
-              (double) (loop * 2 * mpi_comm_size);
-
-    if (mpi_comm_rank == 0)
-        fprintf(stdout, "%-*zu%*.*f", 10, buf_size, NWIDTH, NDIGITS, msg_lat);
-
-    if (mpi_comm_rank == 0)
-        fprintf(stdout, "\n");
+    if (info->na_test_info.mpi_comm_rank == 0)
+        na_test_perf_print_lat(info, buf_size, hg_time_subtract(t2, t1));
 
     return NA_SUCCESS;
 
@@ -142,28 +131,24 @@ main(int argc, char *argv[])
     NA_TEST_CHECK_NA_ERROR(error, na_ret, "na_test_perf_init() failed (%s)",
         NA_Error_to_string(na_ret));
 
-    /* init data */
+    /* Init data */
     na_test_perf_init_data(info.msg_unexp_buf, info.msg_unexp_size_max,
         info.msg_unexp_header_size);
+    if (info.na_test_info.mpi_comm_rank == 0)
+        na_test_perf_send_init(&info);
 
     min_size =
         (info.msg_unexp_header_size > 0) ? info.msg_unexp_header_size : 1;
 
     /* Header info */
-    if (info.na_test_info.mpi_comm_rank == 0) {
-        fprintf(stdout, "# %s v%s\n", BENCHMARK_NAME, VERSION_NAME);
-        fprintf(stdout, "# Loop %d times from size %zu to %zu byte(s)\n",
-            info.na_test_info.loop, min_size, info.msg_unexp_size_max);
-        if (info.na_test_info.verify)
-            fprintf(
-                stdout, "# WARNING verifying data, output will be slower\n");
-        fprintf(stdout, "%-*s%*s\n", 10, "# Size", NWIDTH, "Avg Lat (us)");
-        fflush(stdout);
-    }
+    if (info.na_test_info.mpi_comm_rank == 0)
+        na_test_perf_print_header_lat(&info, BENCHMARK_NAME, min_size);
 
     /* Msg with different sizes */
     for (size = min_size; size <= info.msg_unexp_size_max; size *= 2) {
-        na_ret = na_test_perf_run(&info, size);
+        na_ret = na_test_perf_run(&info, size,
+            (size > NA_TEST_PERF_LARGE_SIZE) ? NA_TEST_PERF_LAT_SKIP_LARGE
+                                             : NA_TEST_PERF_LAT_SKIP_SMALL);
         NA_TEST_CHECK_NA_ERROR(error, na_ret,
             "na_test_perf_run(%zu) failed (%s)", size,
             NA_Error_to_string(na_ret));

--- a/Testing/na/test_perf_server.c
+++ b/Testing/na/test_perf_server.c
@@ -76,6 +76,7 @@ na_test_perf_req_process(const struct na_cb_info *na_cb_info)
         (struct na_test_perf_recv_info *) na_cb_info->arg;
     struct na_test_perf_info *info = recv_info->info;
     na_return_t ret = NA_SUCCESS;
+    size_t i;
 
     recv_info->recv = na_cb_info->info.recv_unexpected;
 
@@ -84,7 +85,8 @@ na_test_perf_req_process(const struct na_cb_info *na_cb_info)
             /* init data separately to avoid a memcpy */
             na_test_perf_init_data(info->msg_exp_buf, info->msg_exp_size_max,
                 info->msg_exp_header_size);
-            NA_FALLTHROUGH;
+            hg_request_complete(info->request);
+            break;
         case NA_TEST_PERF_TAG_LAT:
             /* Respond with same data */
             ret = NA_Msg_send_expected(info->na_class, info->context,
@@ -103,8 +105,11 @@ na_test_perf_req_process(const struct na_cb_info *na_cb_info)
                 NA_Error_to_string(ret));
             break;
         case NA_TEST_PERF_TAG_GET:
-            /* init data */
-            na_test_perf_init_data(info->rma_buf, info->rma_size_max, 0);
+            /* Init data */
+            for (i = 0; i < info->rma_count; i++)
+                na_test_perf_init_data(
+                    (char *) info->rma_buf + i * info->rma_size_max,
+                    info->rma_size_max, 0);
 
             ret = na_test_perf_mem_handle_send(
                 info, recv_info->recv.source, recv_info->recv.tag);


### PR DESCRIPTION
Add -M option to print output in OSU-style Million Bytes/s

Allocate page-size aligned RMA buffers

Clean up and simplify perf tests