### PR TITLE
DAOS-11467 mercury: Add local address to ep when single IB device.

### DIFF
--- a/src/na/na_ucx.c
+++ b/src/na/na_ucx.c
@@ -2145,7 +2145,6 @@ na_ucx_addr_map_insert(struct na_ucx_class *na_ucx_class,
             na_ucx_addr->addr_key.addr, na_ucx_addr->addr_key.addrlen,
             na_ucx_class->origin_addr,
             na_ucp_ep_error_cb, (void *) na_ucx_addr, &na_ucx_addr->ucp_ep);
-	//NA_LOG_SUBSYS_ERROR(addr, "Client added ep: %lu", na_ucx_addr->ucp_ep);
         NA_CHECK_SUBSYS_NA_ERROR(
             addr, error, ret, "Could not connect UCP endpoint");
     }

--- a/src/na/na_ucx.c
+++ b/src/na/na_ucx.c
@@ -1,6 +1,7 @@
 /**
  * 
- * Copyright (c) 2013-2021 UChicago Argonne, LLC and The HDF Group.
+ * Copyright (c) 2013-2022 UChicago Argonne, LLC and The HDF Group.
+ * Copyright (c) 2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */


### PR DESCRIPTION
With UCX, add local address to ep when single IB device is enabled.

Signed-off-by: Joseph Moore <joseph.moore@intel.com>