### PR TITLE
HG: Avoid getting pointer of field if struct pointer is NULL

### DIFF
--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -921,8 +921,14 @@ hg_core_init(const char *na_info_string, hg_bool_t na_listen,
 
     /* Initialize NA if not provided externally */
     if (!hg_core_class->na_ext_init) {
-        hg_core_class->core_class.na_class = NA_Initialize_opt(
-            na_info_string, na_listen, &hg_init_info->na_init_info);
+        if (hg_init_info == NULL) {
+            hg_core_class->core_class.na_class =
+                NA_Initialize(na_info_string, na_listen);
+        } else {
+            hg_core_class->core_class.na_class = NA_Initialize_opt(
+                na_info_string, na_listen, &hg_init_info->na_init_info);
+        }
+
         HG_CHECK_ERROR(hg_core_class->core_class.na_class == NULL, error, ret,
             HG_NA_ERROR, "Could not initialize NA class");
     }


### PR DESCRIPTION
The previous code performs the following operation even if hg_init_info is NULL: &hg_init_info->na_init_info.

This works correctly as na_init_info is the first field of struct hg_init_info.

This change explicitly tests for NULL pointer. Thus, making the code more explicit and simpler to understand (not relying on the order of the fields in the struct). It also avoids the issue being flagged by some code analysis tools.