### PR TITLE
NA OFI: allocate multi-recv buffers using hugepages when available

### DIFF
--- a/Testing/perf/hg/hg_bw_read.c
+++ b/Testing/perf/hg/hg_bw_read.c
@@ -57,7 +57,7 @@ hg_perf_run(const struct hg_test_info *hg_test_info,
             struct hg_perf_bulk_info in_struct = {
                 .comm_rank =
                     (uint32_t) hg_test_info->na_test_info.mpi_comm_rank,
-                .handle_id = (uint32_t) i,
+                .handle_id = (uint32_t) (j / info->target_addr_max),
                 .size = (uint32_t) buf_size};
 
             ret = HG_Forward(

--- a/Testing/perf/hg/hg_bw_write.c
+++ b/Testing/perf/hg/hg_bw_write.c
@@ -57,7 +57,7 @@ hg_perf_run(const struct hg_test_info *hg_test_info,
             struct hg_perf_bulk_info in_struct = {
                 .comm_rank =
                     (uint32_t) hg_test_info->na_test_info.mpi_comm_rank,
-                .handle_id = (uint32_t) i,
+                .handle_id = (uint32_t) (j / info->target_addr_max),
                 .size = (uint32_t) buf_size};
 
             ret = HG_Forward(

--- a/Testing/perf/hg/mercury_perf.h
+++ b/Testing/perf/hg/mercury_perf.h
@@ -56,6 +56,7 @@ struct hg_perf_class_info {
     hg_bulk_t *local_bulk_handles;
     hg_bulk_t *remote_bulk_handles;
     hg_request_t *request; /* Request */
+    int class_id;
     bool done;
     bool verify;
     bool bidir;

--- a/Testing/perf/na/na_perf.c
+++ b/Testing/perf/na/na_perf.c
@@ -203,7 +203,13 @@ na_perf_init(int argc, char *argv[], bool listen, struct na_perf_info *info)
 
     /* Prepare Msg buffers */
     if (multi_recv) {
-        info->msg_unexp_size_max *= 16;
+        size_t hugepage_size = (size_t) hg_mem_get_hugepage_size();
+
+        /* Try to use hugepages */
+        if (hugepage_size > 0)
+            info->msg_unexp_size_max = hugepage_size;
+        else
+            info->msg_unexp_size_max *= 16;
         info->msg_unexp_buf = NA_Msg_buf_alloc(info->na_class,
             info->msg_unexp_size_max, NA_MULTI_RECV, &info->msg_unexp_data);
         NA_TEST_CHECK_ERROR(info->msg_unexp_buf == NULL, error, ret, NA_NOMEM,

--- a/Testing/unit/util/CMakeLists.txt
+++ b/Testing/unit/util/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MERCURY_util_tests
   atomic_queue
   hash_table
   list
+  mem
   mem_pool
   poll
   queue

--- a/Testing/unit/util/test_mem.c
+++ b/Testing/unit/util/test_mem.c
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2013-2022 UChicago Argonne, LLC and The HDF Group.
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "mercury_mem.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+main(void)
+{
+    size_t page_size;
+    void *ptr;
+
+    page_size = (size_t) hg_mem_get_page_size();
+    if (page_size == 0) {
+        fprintf(stderr, "Error: page size is 0\n");
+        goto error;
+    }
+
+    ptr = hg_mem_aligned_alloc(page_size, page_size * 4);
+    if (ptr == NULL) {
+        fprintf(stderr, "Error: could not allocate %ld bytes\n", page_size * 4);
+        goto error;
+    }
+    hg_mem_aligned_free(ptr);
+
+    page_size = (size_t) hg_mem_get_hugepage_size();
+    if (page_size == 0) {
+        fprintf(stderr, "Warning: hugepage size is 0\n");
+    } else {
+        ptr = hg_mem_huge_alloc(page_size * 4);
+        if (ptr != NULL)
+            (void) hg_mem_huge_free(ptr, page_size * 4);
+    }
+
+    return EXIT_SUCCESS;
+
+error:
+    return EXIT_FAILURE;
+}

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -42,8 +42,8 @@
 #define HG_CORE_ATOMIC_QUEUE_SIZE (1024)
 
 /* Pre-posted requests and op IDs */
-#define HG_CORE_POST_INIT          (256)
-#define HG_CORE_POST_INCR          (256)
+#define HG_CORE_POST_INIT          (512)
+#define HG_CORE_POST_INCR          (512)
 #define HG_CORE_BULK_OP_INIT_COUNT (256)
 
 /* Number of multi-recv buffer pre-posted */

--- a/src/na/na_types.h
+++ b/src/na/na_types.h
@@ -184,7 +184,7 @@ typedef void (*na_cb_t)(const struct na_cb_info *callback_info);
 #define NA_MINOR(version)        (version & 0xffff)
 
 /* Optional plugin dependent features that can be queried */
-#define NA_OPT_MULTI_RECV (2 << 1) /* multi-recv */
+#define NA_OPT_MULTI_RECV (1 << 0) /* multi-recv */
 
 /* Max timeout */
 #define NA_MAX_IDLE_TIME (3600 * 1000)
@@ -195,9 +195,10 @@ typedef void (*na_cb_t)(const struct na_cb_info *callback_info);
 
 /* Memory allocation flags
  * \remark Used for message buffer allocation. */
-#define NA_SEND       0x01
-#define NA_RECV       0x02
-#define NA_MULTI_RECV 0x04
+#define NA_SEND       (1 << 0)
+#define NA_RECV       (1 << 1)
+#define NA_MULTI_RECV (1 << 2)
+#define NA_ALLOC_MAX  (1 << 3) /* Maximum flag value */
 
 /* Op ID creation flags */
 #define NA_OP_SINGLE 0x00

--- a/src/util/mercury_mem.h
+++ b/src/util/mercury_mem.h
@@ -32,10 +32,18 @@ extern "C" {
 /**
  * Get system default page size.
  *
- * \return page size on success or negative on failure
+ * \return page size on success or 0 on failure
  */
 HG_UTIL_PUBLIC long
 hg_mem_get_page_size(void);
+
+/**
+ * Get system default hugepage size.
+ *
+ * \return hugepage size on success or 0 on failure
+ */
+HG_UTIL_PUBLIC long
+hg_mem_get_hugepage_size(void);
 
 /**
  * Allocate size bytes and return a pointer to the allocated memory.
@@ -57,6 +65,26 @@ hg_mem_aligned_alloc(size_t alignment, size_t size);
  */
 HG_UTIL_PUBLIC void
 hg_mem_aligned_free(void *mem_ptr);
+
+/**
+ * Allocate size bytes using huge pages and return a pointer to the allocated
+ * memory.
+ *
+ * \param size [IN]             total requested size
+ *
+ * \return a pointer to the allocated memory, or NULL in case of failure
+ */
+HG_UTIL_PUBLIC void *
+hg_mem_huge_alloc(size_t size);
+
+/**
+ * Free memory allocated from hg_mem_huge_alloc().
+ *
+ * \param mem_ptr [IN]          pointer to allocated memory
+ * \param size [IN]             allocated size
+ */
+HG_UTIL_PUBLIC int
+hg_mem_huge_free(void *mem_ptr, size_t size);
 
 /**
  * Allocate a buffer with a `size`-bytes, `alignment`-aligned payload


### PR DESCRIPTION
HG util: add support for hugepage allocations

Testing: add mem util test

HG Core: bump pre-allocated requests to 512 to make use of 2M hugepages

NA perf: update perf test to use hugepages

NA: fix some multi-recv constants