### PR TITLE
Use isb for cpu_spinwait on aarch64

### DIFF
--- a/src/util/mercury_atomic_queue.h
+++ b/src/util/mercury_atomic_queue.h
@@ -50,6 +50,8 @@
 #        define cpu_spinwait _mm_pause
 #    elif defined(__arm__)
 #        define cpu_spinwait() __asm__ __volatile__("yield")
+#    elif defined(__aarch64__)
+#        define cpu_spinwait() __asm__ __volatile__("isb")
 #    else
 #        warning "Processor yield is not supported on this architecture."
 #        define cpu_spinwait(x)


### PR DESCRIPTION
This is used by some projects like sse2neon and rust (https://github.com/rust-lang/rust/commit/c064b6560b7ce0adeb9bbf5d7dcf12b1acb0c807).