### PR TITLE
NA OFI: add NA_OFI_OP_RETRY_TIMEOUT and NA_OFI_OP_RETRY_PERIOD

### DIFF
--- a/Testing/common/mercury_test_config.h.in
+++ b/Testing/common/mercury_test_config.h.in
@@ -40,6 +40,12 @@
 /* Test options */
 #cmakedefine HG_TEST_TEMP_DIRECTORY "@HG_TEST_TEMP_DIRECTORY@"
 
+/* Timeout (in seconds) */
+#cmakedefine HG_TEST_TIMEOUT (@DART_TESTING_TIMEOUT@ / 2)
+#ifndef HG_TEST_TIMEOUT
+#    define HG_TEST_TIMEOUT 240
+#endif
+
 /* Number of threads */
 #define HG_TEST_NUM_THREADS_DEFAULT (8)
 

--- a/Testing/unit/hg/mercury_unit.h
+++ b/Testing/unit/hg/mercury_unit.h
@@ -29,8 +29,11 @@ struct hg_unit_info {
     hg_context_t **secondary_contexts;
     hg_request_class_t *request_class;
     hg_addr_t target_addr;
+    hg_handle_t *handles;
     hg_thread_pool_t *thread_pool;
-    hg_size_t buf_size_max;
+    size_t handle_max;
+    size_t buf_size_max;
+    hg_request_t *request;
 };
 
 struct hg_test_context_info {

--- a/src/mercury_config.h.in
+++ b/src/mercury_config.h.in
@@ -58,18 +58,24 @@ typedef hg_uint8_t hg_bool_t;
 
 #include <mercury_compiler_attributes.h>
 
-/* Inline macro */
+/* Unused return values */
+#define HG_WARN_UNUSED_RESULT HG_ATTR_WARN_UNUSED_RESULT
+
+/* Unused variables */
+#define HG_UNUSED HG_ATTR_UNUSED
+
+/* Packed */
+#define HG_PACKED(x) HG_ATTR_PACKED(x)
+
+/* Fallthrough */
+#define HG_FALLTHROUGH HG_ATTR_FALLTHROUGH
+
+/* Inline */
 #ifdef _WIN32
 #    define HG_INLINE __inline
 #else
 #    define HG_INLINE __inline__
 #endif
-
-/* Packed */
-#define HG_PACKED(x) HG_ATTR_PACKED(x)
-
-/* Fallthrough macro */
-#define HG_FALLTHROUGH HG_ATTR_FALLTHROUGH
 
 /* Shared libraries */
 #cmakedefine HG_BUILD_SHARED_LIBS
@@ -86,10 +92,15 @@ typedef hg_uint8_t hg_bool_t;
 #endif
 
 /* Build Options */
-#cmakedefine HG_HAS_BOOST
-#cmakedefine HG_HAS_CHECKSUMS
-#cmakedefine HG_HAS_XDR
-
 #cmakedefine HG_HAS_DEBUG
+
+/* Boost */
+#cmakedefine HG_HAS_BOOST
+
+/* Checksums */
+#cmakedefine HG_HAS_CHECKSUMS
+
+/* XDR */
+#cmakedefine HG_HAS_XDR
 
 #endif /* MERCURY_CONFIG_H */

--- a/src/mercury_private.h
+++ b/src/mercury_private.h
@@ -43,6 +43,12 @@ struct hg_bulk_op_pool;
 /* Public Macros */
 /*****************/
 
+#ifdef HG_HAS_DEBUG
+#    define HG_DEBUG_LOG_USED
+#else
+#    define HG_DEBUG_LOG_USED HG_UNUSED
+#endif
+
 /**
  * container_of - cast a member of a structure out to the containing structure
  * \ptr:        the pointer to the member.


### PR DESCRIPTION
Once NA_OFI_OP_RETRY_TIMEOUT milliseconds elapse, retry is stopped and operation is aborted (default is 120000ms)

When NA_OFI_OP_RETRY_PERIOD is set, operations are retried only every NA_OFI_OP_RETRY_PERIOD milliseconds (default is 0).