### PR TITLE
HG: disable early release of input buffers by default w/ multi_recv

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -45,6 +45,7 @@ struct hg_private_class {
     void *handle_create_arg;                           /* handle_create arg */
     hg_checksum_level_t checksum_level;                /* Checksum level */
     hg_bool_t bulk_eager;                              /* Eager bulk proc */
+    hg_bool_t release_input_early;                     /* Release input early */
 };
 
 /* Info for function map */
@@ -540,7 +541,8 @@ hg_get_struct(struct hg_private_handle *hg_handle,
 #endif
 
 #ifndef HG_HAS_XDR
-    if (op == HG_INPUT) {
+    if (HG_HANDLE_CLASS(&hg_handle->handle)->release_input_early &&
+        op == HG_INPUT) {
         /* Now that the parameters have been decoded, release the buffer so it
          * can be re-used while the RPC is being executed. */
         ret = HG_Core_release_input(hg_handle->handle.core_handle);
@@ -1057,6 +1059,10 @@ HG_Init_opt(const char *na_info_string, hg_bool_t na_listen,
         "Option checksum_level requires CMake option MERCURY_USE_CHECKSUMS to "
         "be turned ON.");
 #endif
+
+    /* Release input early */
+    hg_class->release_input_early =
+        (hg_init_info) ? hg_init_info->release_input_early : HG_FALSE;
 
     hg_class->hg_class.core_class =
         HG_Core_init_opt(na_info_string, na_listen, hg_init_info);

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -732,6 +732,10 @@ HG_Get_data(hg_handle_t handle);
  *   - HG_Core_get_input()
  *   - Call hg_proc to deserialize parameters
  *
+ * \remark The input buffer may be released automatically after that call if the
+ * release_input_early init info parameter has been set when initializing the
+ * HG class.
+ *
  * \param handle [IN]           HG handle
  * \param in_struct [IN/OUT]    pointer to input structure
  *
@@ -808,9 +812,9 @@ HG_Get_input_buf(hg_handle_t handle, void **in_buf_p, hg_size_t *in_buf_size_p);
 /**
  * Release input buffer from handle so that it can be re-used early.
  *
- * \remark HG_Release_input_buf() should only be called when using
- * HG_Get_input_buf(). When using HG_Get_input(), the input buffer will be
- * internally released after HG_Get_input() has been called. Note also that
+ * \remark HG_Release_input_buf() may only be called when using
+ * HG_Get_input_buf(). When using HG_Get_input(), the input buffer may
+ * internally be released after HG_Get_input() is called. Note also that
  * if HG_Release_input_buf() is not called, the input buffer will later be
  * released when calling HG_Destroy().
  *

--- a/src/mercury_core_types.h
+++ b/src/mercury_core_types.h
@@ -92,6 +92,12 @@ struct hg_init_info {
     /* Disable use of multi_recv when available and post separate buffers.
      * Default is: false */
     hg_bool_t no_multi_recv;
+
+    /* Release input buffers as early as possible (usually after HG_Get_input())
+     * as opposed to releasing them after a call to handle destroy. This may be
+     * beneficial in cases where the RPC execution time is longer than usual.
+     * Default is: false */
+    hg_bool_t release_input_early;
 };
 
 /* Error return codes:
@@ -184,7 +190,7 @@ typedef enum {
         .request_post_init = 0, .request_post_incr = 0, .auto_sm = HG_FALSE,   \
         .sm_info_string = NULL, .checksum_level = HG_CHECKSUM_NONE,            \
         .no_bulk_eager = HG_FALSE, .no_loopback = HG_FALSE, .stats = HG_FALSE, \
-        .no_multi_recv = HG_FALSE                                              \
+        .no_multi_recv = HG_FALSE, .release_input_early = HG_FALSE             \
     }
 
 #endif /* MERCURY_CORE_TYPES_H */


### PR DESCRIPTION
Add release_input_early init info flag to release input buffers early