### PR TITLE
Remove HG_ATOMIC_VAR_INIT

### DIFF
--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -2109,7 +2109,7 @@ static na_return_t
 na_sm_endpoint_open(struct na_sm_endpoint *na_sm_endpoint, const char *name,
     bool listen, bool no_wait, uint32_t nofile_max)
 {
-    static hg_atomic_int32_t sm_id_g = HG_ATOMIC_VAR_INIT(0);
+    static hg_atomic_int32_t sm_id_g = 0;
     struct na_sm_addr_key addr_key = {0, 0};
     struct na_sm_region *shared_region = NULL;
     char uri[NA_SM_MAX_FILENAME], *uri_p = NULL;

--- a/src/util/mercury_atomic.h
+++ b/src/util/mercury_atomic.h
@@ -19,9 +19,6 @@ typedef struct {
 typedef struct {
     volatile LONGLONG value;
 } hg_atomic_int64_t;
-/* clang-format off */
-#    define HG_ATOMIC_VAR_INIT(x) {(x)}
-/* clang-format on */
 #elif defined(HG_UTIL_HAS_STDATOMIC_H)
 #    ifndef __cplusplus
 #        include <stdatomic.h>
@@ -45,12 +42,6 @@ using std::memory_order_acq_rel;
 using std::memory_order_acquire;
 using std::memory_order_release;
 #    endif
-#    if (__STDC_VERSION__ >= 201710L ||                                        \
-         (defined(__cplusplus) && __cplusplus >= 202002L))
-#        define HG_ATOMIC_VAR_INIT(x) (x)
-#    else
-#        define HG_ATOMIC_VAR_INIT(x) ATOMIC_VAR_INIT(x)
-#    endif
 #elif defined(__APPLE__)
 #    include <libkern/OSAtomic.h>
 typedef struct {
@@ -59,9 +50,6 @@ typedef struct {
 typedef struct {
     volatile int64_t value;
 } hg_atomic_int64_t;
-/* clang-format off */
-#    define HG_ATOMIC_VAR_INIT(x) {(x)}
-/* clang-format on */
 #else /* GCC 4.7 */
 #    if !defined(__GNUC__) || ((__GNUC__ < 4) && (__GNUC_MINOR__ < 7))
 #        error "GCC version >= 4.7 required to support built-in atomics."
@@ -69,7 +57,6 @@ typedef struct {
 /* builtins do not require volatile */
 typedef int32_t hg_atomic_int32_t;
 typedef int64_t hg_atomic_int64_t;
-#    define HG_ATOMIC_VAR_INIT(x) (x)
 #endif
 
 #ifdef __cplusplus

--- a/src/util/mercury_mem.c
+++ b/src/util/mercury_mem.c
@@ -28,7 +28,7 @@
 long
 hg_mem_get_page_size(void)
 {
-    static hg_atomic_int64_t atomic_page_size = HG_ATOMIC_VAR_INIT(0);
+    static hg_atomic_int64_t atomic_page_size = 0;
     long page_size = (long) hg_atomic_get64(&atomic_page_size);
 
     if (page_size != 0)
@@ -55,7 +55,7 @@ hg_mem_get_hugepage_size(void)
     char *line = NULL;
     size_t len = 0;
 #endif
-    static hg_atomic_int64_t atomic_page_size = HG_ATOMIC_VAR_INIT(0);
+    static hg_atomic_int64_t atomic_page_size = 0;
     long page_size = (long) hg_atomic_get64(&atomic_page_size);
 
     if (page_size != 0)


### PR DESCRIPTION
ATOMIC_VAR_INIT has a trivial definition
`#define ATOMIC_VAR_INIT(value) (value)`,
is deprecated in C17/C++20, and will be removed in newer standards in newer GCC/Clang (e.g. https://reviews.llvm.org/D144196). Just remove the HG_ATOMIC_VAR_INIT wrapper.