### PR TITLE
HG util: Revert "Remove HG_ATOMIC_VAR_INIT"

### DIFF
--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -2109,7 +2109,7 @@ static na_return_t
 na_sm_endpoint_open(struct na_sm_endpoint *na_sm_endpoint, const char *name,
     bool listen, bool no_wait, uint32_t nofile_max)
 {
-    static hg_atomic_int32_t sm_id_g = 0;
+    static hg_atomic_int32_t sm_id_g = HG_ATOMIC_VAR_INIT(0);
     struct na_sm_addr_key addr_key = {0, 0};
     struct na_sm_region *shared_region = NULL;
     char uri[NA_SM_MAX_FILENAME], *uri_p = NULL;

--- a/src/util/mercury_atomic.h
+++ b/src/util/mercury_atomic.h
@@ -19,6 +19,9 @@ typedef struct {
 typedef struct {
     volatile LONGLONG value;
 } hg_atomic_int64_t;
+/* clang-format off */
+#    define HG_ATOMIC_VAR_INIT(x) {(x)}
+/* clang-format on */
 #elif defined(HG_UTIL_HAS_STDATOMIC_H)
 #    ifndef __cplusplus
 #        include <stdatomic.h>
@@ -42,6 +45,12 @@ using std::memory_order_acq_rel;
 using std::memory_order_acquire;
 using std::memory_order_release;
 #    endif
+#    if (__STDC_VERSION__ >= 201710L ||                                        \
+         (defined(__cplusplus) && __cplusplus >= 202002L))
+#        define HG_ATOMIC_VAR_INIT(x) (x)
+#    else
+#        define HG_ATOMIC_VAR_INIT(x) ATOMIC_VAR_INIT(x)
+#    endif
 #elif defined(__APPLE__)
 #    include <libkern/OSAtomic.h>
 typedef struct {
@@ -50,6 +59,9 @@ typedef struct {
 typedef struct {
     volatile int64_t value;
 } hg_atomic_int64_t;
+/* clang-format off */
+#    define HG_ATOMIC_VAR_INIT(x) {(x)}
+/* clang-format on */
 #else /* GCC 4.7 */
 #    if !defined(__GNUC__) || ((__GNUC__ < 4) && (__GNUC_MINOR__ < 7))
 #        error "GCC version >= 4.7 required to support built-in atomics."
@@ -57,6 +69,7 @@ typedef struct {
 /* builtins do not require volatile */
 typedef int32_t hg_atomic_int32_t;
 typedef int64_t hg_atomic_int64_t;
+#    define HG_ATOMIC_VAR_INIT(x) (x)
 #endif
 
 #ifdef __cplusplus

--- a/src/util/mercury_mem.c
+++ b/src/util/mercury_mem.c
@@ -28,7 +28,7 @@
 long
 hg_mem_get_page_size(void)
 {
-    static hg_atomic_int64_t atomic_page_size = 0;
+    static hg_atomic_int64_t atomic_page_size = HG_ATOMIC_VAR_INIT(0);
     long page_size = (long) hg_atomic_get64(&atomic_page_size);
 
     if (page_size != 0)
@@ -55,7 +55,7 @@ hg_mem_get_hugepage_size(void)
     char *line = NULL;
     size_t len = 0;
 #endif
-    static hg_atomic_int64_t atomic_page_size = 0;
+    static hg_atomic_int64_t atomic_page_size = HG_ATOMIC_VAR_INIT(0);
     long page_size = (long) hg_atomic_get64(&atomic_page_size);
 
     if (page_size != 0)


### PR DESCRIPTION
Revert commit 508bc98f111778f1fe64af336f16ba73df89f4fa for now as this would potentially cause initialization issues with WIN32/MacOS builds. Will re-apply once atomic support has been updated for those platforms.