### PR TITLE
HG: prevent ABI breakage from updated info struct

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12.2 FATAL_ERROR)
 project(MercuryExamples C)
 
 #------------------------------------------------------------------------------

--- a/Examples/src/example_rpc.c
+++ b/Examples/src/example_rpc.c
@@ -6,6 +6,7 @@
  */
 
 #include "example_rpc.h"
+#include "example_rpc_engine.h"
 
 #include <aio.h>
 #include <assert.h>
@@ -77,7 +78,7 @@ my_rpc_register(void)
 static hg_return_t
 my_rpc_handler(hg_handle_t handle)
 {
-    int ret;
+    hg_return_t ret;
     struct my_rpc_state *my_rpc_state_p;
     const struct hg_info *hgi;
 
@@ -157,11 +158,13 @@ static void
 my_rpc_handler_write_cb(union sigval sig)
 {
     struct my_rpc_state *my_rpc_state_p = sig.sival_ptr;
-    int ret;
+    hg_return_t ret;
+    int rc;
     my_rpc_out_t out;
 
-    ret = aio_error(&my_rpc_state_p->acb);
-    assert(ret == 0);
+    rc = aio_error(&my_rpc_state_p->acb);
+    assert(rc == 0);
+    (void) rc;
     out.ret = 0;
 
     /* NOTE: really this should be nonblocking */

--- a/Examples/src/example_rpc.h
+++ b/Examples/src/example_rpc.h
@@ -5,15 +5,47 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "example_rpc_engine.h"
-
 #ifndef EXAMPLE_RPC_H
-#    define EXAMPLE_RPC_H
+#define EXAMPLE_RPC_H
 
+#include <mercury_macros.h>
+
+#ifdef HG_HAS_BOOST
 /* visible API for example RPC operation */
+MERCURY_GEN_PROC(my_rpc_out_t, ((int32_t) (ret)))
+MERCURY_GEN_PROC(
+    my_rpc_in_t, ((int32_t) (input_val))((hg_bulk_t) (bulk_handle)))
+#else
+typedef struct {
+    int32_t ret;
+} my_rpc_out_t;
 
-MERCURY_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(my_rpc_in_t, ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
+typedef struct {
+    int32_t input_val;
+    hg_bulk_t bulk_handle;
+} my_rpc_in_t;
+
+static HG_INLINE hg_return_t
+hg_proc_my_rpc_in_t(hg_proc_t proc, void *data)
+{
+    my_rpc_in_t *in = (my_rpc_in_t *) data;
+
+    (void) hg_proc_int32_t(proc, &in->input_val);
+    (void) hg_proc_hg_bulk_t(proc, &in->bulk_handle);
+
+    return HG_SUCCESS;
+}
+
+static HG_INLINE hg_return_t
+hg_proc_my_rpc_out_t(hg_proc_t proc, void *data)
+{
+    my_rpc_out_t *out = (my_rpc_out_t *) data;
+
+    (void) hg_proc_int32_t(proc, &out->ret);
+
+    return HG_SUCCESS;
+}
+#endif
 
 hg_id_t
 my_rpc_register(void);

--- a/Examples/src/example_rpc_client.c
+++ b/Examples/src/example_rpc_client.c
@@ -87,7 +87,7 @@ run_my_rpc(const char *svr_addr_string, int value)
     hg_addr_t svr_addr;
     my_rpc_in_t in;
     const struct hg_info *hgi;
-    int ret;
+    hg_return_t ret;
     struct my_rpc_state *my_rpc_state_p;
 
     /* address lookup. */
@@ -131,7 +131,7 @@ static hg_return_t
 my_rpc_cb(const struct hg_cb_info *info)
 {
     my_rpc_out_t out;
-    int ret;
+    hg_return_t ret;
     struct my_rpc_state *my_rpc_state_p = info->arg;
 
     assert(info->ret == HG_SUCCESS);

--- a/Examples/src/example_rpc_engine.h
+++ b/Examples/src/example_rpc_engine.h
@@ -5,18 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#ifndef EXAMPLE_RPC_ENGINE_H
+#define EXAMPLE_RPC_ENGINE_H
+
 #include <mercury.h>
-#include <mercury_bulk.h>
-#include <mercury_macros.h>
 
 /* example_rpc_engine: API of generic utilities and progress engine hooks that
  * are reused across many RPC functions.  init and finalize() manage a
  * dedicated thread that will drive all HG progress
  */
-
-#ifndef EXAMPLE_RPC_ENGINE_H
-#    define EXAMPLE_RPC_ENGINE_H
-
 void
 hg_engine_init(hg_bool_t listen, const char *local_addr);
 void

--- a/Examples/src/example_snappy.c
+++ b/Examples/src/example_snappy.c
@@ -7,6 +7,7 @@
 
 #include "example_snappy.h"
 
+#include <inttypes.h>
 #include <snappy-c.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -58,14 +59,14 @@ snappy_pull_cb(const struct hg_cb_info *hg_cb_info)
         (struct snappy_transfer_args *) hg_cb_info->arg;
     hg_return_t ret = HG_SUCCESS;
     void *input;
-    size_t input_length;
+    hg_size_t input_length;
     size_t source_length =
         HG_Bulk_get_size(snappy_transfer_args->local_input_bulk_handle);
 
     /* Get pointer to input buffer from local handle */
     HG_Bulk_access(hg_cb_info->info.bulk.local_handle, 0, source_length,
         HG_BULK_READ_ONLY, 1, &input, &input_length, NULL);
-    printf("Transferred input buffer of length: %zu\n", input_length);
+    printf("Transferred input buffer of length: %" PRIu64 "\n", input_length);
     print_buf(20, (int *) input);
 
     /* Allocate compressed buffer for compressing input data */
@@ -122,7 +123,7 @@ snappy_push_cb(const struct hg_cb_info *hg_cb_info)
     snappy_compress_out_t snappy_compress_output;
 
     /* Set output parameters to inform origin */
-    snappy_compress_output.ret = snappy_transfer_args->ret;
+    snappy_compress_output.ret = (hg_int32_t) snappy_transfer_args->ret;
     snappy_compress_output.compressed_length =
         snappy_transfer_args->compressed_length;
     printf("Transferred compressed buffer of length %zu\n",

--- a/Examples/src/example_snappy.h
+++ b/Examples/src/example_snappy.h
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#ifndef EXAMPLE_SNAPPY_H
+#define EXAMPLE_SNAPPY_H
+
 #include <mercury_macros.h>
 
-#ifndef EXAMPLE_SNAPPY_H
-#    define EXAMPLE_SNAPPY_H
-
-#    define TEMP_DIRECTORY   "."
-#    define CONFIG_FILE_NAME "/port.cfg"
+#define TEMP_DIRECTORY   "."
+#define CONFIG_FILE_NAME "/port.cfg"
 
 extern hg_bool_t snappy_compress_done_target_g;
 
@@ -24,6 +24,7 @@ extern hg_bool_t snappy_compress_done_target_g;
  *                                 size_t* compressed_length);
  */
 
+#ifdef HG_HAS_BOOST
 /* The MERCURY_GEN_PROC macro creates a new compound type consisting of
  * the members listed.
  *
@@ -32,13 +33,46 @@ extern hg_bool_t snappy_compress_done_target_g;
  * - compressed_bulk_handle: describes compressed/compressed_length
  */
 MERCURY_GEN_PROC(snappy_compress_in_t,
-    ((hg_bulk_t)(input_bulk_handle))((hg_bulk_t)(compressed_bulk_handle)))
+    ((hg_bulk_t) (input_bulk_handle))((hg_bulk_t) (compressed_bulk_handle)))
 
 /* snappy_compress_out_t will contain output members:
  * - ret: snappy_status enum, the return type uses hg_int32_t as a base type
  */
-MERCURY_GEN_PROC(
-    snappy_compress_out_t, ((hg_int32_t)(ret))((hg_size_t)(compressed_length)))
+MERCURY_GEN_PROC(snappy_compress_out_t,
+    ((hg_int32_t) (ret))((hg_size_t) (compressed_length)))
+#else
+typedef struct {
+    hg_bulk_t input_bulk_handle;
+    hg_bulk_t compressed_bulk_handle;
+} snappy_compress_in_t;
+
+typedef struct {
+    hg_int32_t ret;
+    hg_size_t compressed_length;
+} snappy_compress_out_t;
+
+static HG_INLINE hg_return_t
+hg_proc_snappy_compress_in_t(hg_proc_t proc, void *data)
+{
+    snappy_compress_in_t *in = (snappy_compress_in_t *) data;
+
+    (void) hg_proc_hg_bulk_t(proc, &in->input_bulk_handle);
+    (void) hg_proc_hg_bulk_t(proc, &in->compressed_bulk_handle);
+
+    return HG_SUCCESS;
+}
+
+static HG_INLINE hg_return_t
+hg_proc_snappy_compress_out_t(hg_proc_t proc, void *data)
+{
+    snappy_compress_out_t *out = (snappy_compress_out_t *) data;
+
+    (void) hg_proc_int32_t(proc, &out->ret);
+    (void) hg_proc_hg_size_t(proc, &out->compressed_length);
+
+    return HG_SUCCESS;
+}
+#endif
 
 /**
  * Convenient to have both origin and target call a "register" routine

--- a/Examples/src/example_snappy_client.c
+++ b/Examples/src/example_snappy_client.c
@@ -58,7 +58,7 @@ snappy_compress_rpc_cb(const struct hg_cb_info *callback_info)
     HG_Get_output(handle, &snappy_compress_output);
 
     /* Get Snappy output parameters */
-    ret = snappy_compress_output.ret;
+    ret = (snappy_status) snappy_compress_output.ret;
     compressed_length = snappy_compress_output.compressed_length;
     compressed = snappy_compress_rpc_args->compressed;
     input = snappy_compress_rpc_args->input;

--- a/Testing/common/mercury_test.c
+++ b/Testing/common/mercury_test.c
@@ -240,9 +240,10 @@ HG_Test_init(int argc, char *argv[], struct hg_test_info *hg_test_info)
 
         /* Init HG with init options */
         hg_test_info->hg_classes[i] =
-            HG_Init_opt(NULL, hg_test_info->na_test_info.listen, &hg_init_info);
+            HG_Init_opt2(NULL, hg_test_info->na_test_info.listen,
+                HG_VERSION(HG_VERSION_MAJOR, HG_VERSION_MINOR), &hg_init_info);
         HG_TEST_CHECK_ERROR(hg_test_info->hg_classes[i] == NULL, error, ret,
-            HG_FAULT, "HG_Init_opt() failed");
+            HG_FAULT, "HG_Init_opt2() failed");
     }
     hg_test_info->hg_class = hg_test_info->hg_classes[0]; /* default */
 

--- a/Testing/common/na_test.c
+++ b/Testing/common/na_test.c
@@ -566,9 +566,10 @@ NA_Test_init(int argc, char *argv[], struct na_test_info *na_test_info)
             printf("# Class %d using info string: %s\n", i + 1, info_string);
 
         na_test_info->na_classes[i] =
-            NA_Initialize_opt(info_string, na_test_info->listen, &na_init_info);
+            NA_Initialize_opt2(info_string, na_test_info->listen,
+                NA_VERSION(NA_VERSION_MAJOR, NA_VERSION_MINOR), &na_init_info);
         NA_TEST_CHECK_ERROR(na_test_info->na_classes[i] == NULL, error, ret,
-            NA_PROTOCOL_ERROR, "NA_Initialize_opt(%s) failed", info_string);
+            NA_PROTOCOL_ERROR, "NA_Initialize_opt2(%s) failed", info_string);
 
         free(info_string);
         info_string = NULL;

--- a/Testing/script/gh_install_deps.sh
+++ b/Testing/script/gh_install_deps.sh
@@ -10,7 +10,7 @@ if [[ $MERCURY_BUILD_CONFIGURATION == 'Debug' ]]; then
   OFI_EXTRA_FLAGS="--enable-debug"
 fi
 #OFI_PR=
-OFI_VERSION=1.18.0rc2
+OFI_VERSION=1.18.0
 
 # UCX
 if [[ $MERCURY_BUILD_CONFIGURATION == 'Tsan' ]]; then

--- a/Testing/script/gh_script.cmake
+++ b/Testing/script/gh_script.cmake
@@ -202,6 +202,12 @@ set(CTEST_BUILD_NAME "${BUILD_NAME}-${OS_NAME}-$ENV{CC}-${lower_mercury_build_co
 
 set(dashboard_binary_name mercury-${lower_mercury_build_configuration})
 
+if(NOT DEFINED MERCURY_MEMORYCHECK_TYPE AND NOT MERCURY_DO_COVERAGE)
+  set(build_examples TRUE)
+else()
+  set(build_examples FALSE)
+endif()
+
 # OS specific options
 if(APPLE)
   set(SOEXT dylib)
@@ -246,6 +252,7 @@ set(dashboard_cache "
 CMAKE_C_FLAGS:STRING=${MERCURY_C_FLAGS}
 CMAKE_CXX_FLAGS:STRING=${MERCURY_CXX_FLAGS}
 
+BUILD_EXAMPLES:BOOL=${build_examples}
 BUILD_SHARED_LIBS:BOOL=${build_shared_libs}
 BUILD_TESTING:BOOL=ON
 

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -74,7 +74,9 @@ HG_Init(const char *na_info_string, hg_bool_t na_listen);
 
 /**
  * Initialize the Mercury layer with options provided by init_info.
- * Must be finalized with HG_Finalize().
+ * Must be finalized with HG_Finalize(). Using this routine limits the info
+ * struct version to 2.2 version. It is recommended to use \HG_Init_opt2() for
+ * mercury versions >= 2.3.0.
  * \remark HG_Init_opt() may become HG_Init() in the future.
  *
  * \param na_info_string [IN]   host address with port number (e.g.,
@@ -88,6 +90,24 @@ HG_Init(const char *na_info_string, hg_bool_t na_listen);
 HG_PUBLIC hg_class_t *
 HG_Init_opt(const char *na_info_string, hg_bool_t na_listen,
     const struct hg_init_info *hg_init_info);
+
+/**
+ * Initialize the Mercury layer with options provided by init_info.
+ * Must be finalized with HG_Finalize().
+ * \remark HG_Init_opt() may become HG_Init() in the future.
+ *
+ * \param na_info_string [IN]   host address with port number (e.g.,
+ *                              "tcp://localhost:3344" or
+ *                              "bmi+tcp://localhost:3344")
+ * \param na_listen [IN]        listen for incoming connections
+ * \param version [IN]          API version of the init info struct
+ * \param hg_init_info [IN]     (Optional) HG init info, NULL if no info
+ *
+ * \return Pointer to HG class or NULL in case of failure
+ */
+HG_PUBLIC hg_class_t *
+HG_Init_opt2(const char *na_info_string, hg_bool_t na_listen,
+    unsigned int version, const struct hg_init_info *hg_init_info);
 
 /**
  * Finalize the Mercury layer.

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -99,7 +99,8 @@ HG_Core_init(const char *na_info_string, hg_bool_t na_listen);
 
 /**
  * Initialize the Mercury layer with options provided by init_info.
- * Must be finalized with HG_Core_finalize().
+ * Must be finalized with HG_Core_finalize(). Using this routine limits the info
+ * struct version to 2.2 version.
  * \remark HG_Core_init_opt() may become HG_Core_init() in the future.
  *
  * \param na_info_string [IN]   host address with port number (e.g.,
@@ -113,6 +114,24 @@ HG_Core_init(const char *na_info_string, hg_bool_t na_listen);
 HG_PUBLIC hg_core_class_t *
 HG_Core_init_opt(const char *na_info_string, hg_bool_t na_listen,
     const struct hg_init_info *hg_init_info);
+
+/**
+ * Initialize the Mercury layer with options provided by init_info.
+ * Must be finalized with HG_Core_finalize().
+ * \remark HG_Core_init_opt() may become HG_Core_init() in the future.
+ *
+ * \param na_info_string [IN]   host address with port number (e.g.,
+ *                              "tcp://localhost:3344" or
+ *                              "bmi+tcp://localhost:3344")
+ * \param na_listen [IN]        listen for incoming connections
+ * \param version [IN]          API version of the init info struct
+ * \param hg_init_info [IN]     (Optional) HG init info, NULL if no info
+ *
+ * \return Pointer to HG core class or NULL in case of failure
+ */
+HG_PUBLIC hg_core_class_t *
+HG_Core_init_opt2(const char *na_info_string, hg_bool_t na_listen,
+    unsigned int version, const struct hg_init_info *hg_init_info);
 
 /**
  * Finalize the Mercury layer.

--- a/src/mercury_core_types.h
+++ b/src/mercury_core_types.h
@@ -31,9 +31,6 @@ typedef enum hg_checksum_level {
  * NB. should be initialized using HG_INIT_INFO_INITIALIZER
  */
 struct hg_init_info {
-    /* Requested API version. */
-    hg_uint32_t api_version;
-
     /* NA init info struct, see na_types.h for documentation */
     struct na_init_info na_init_info;
 
@@ -174,6 +171,8 @@ typedef enum {
 #define HG_VERSION(major, minor) (((major) << 16) | (minor))
 #define HG_MAJOR(version)        (version >> 16)
 #define HG_MINOR(version)        (version & 0xffff)
+#define HG_VERSION_GE(v1, v2)    (v1 >= v2)
+#define HG_VERSION_LT(v1, v2)    (v1 < v2)
 
 /* Max timeout */
 #define HG_MAX_IDLE_TIME (3600 * 1000)
@@ -185,7 +184,6 @@ typedef enum {
 #define HG_INIT_INFO_INITIALIZER                                               \
     (struct hg_init_info)                                                      \
     {                                                                          \
-        .api_version = HG_VERSION(HG_VERSION_MAJOR, HG_VERSION_MINOR),         \
         .na_init_info = NA_INIT_INFO_INITIALIZER, .na_class = NULL,            \
         .request_post_init = 0, .request_post_incr = 0, .auto_sm = HG_FALSE,   \
         .sm_info_string = NULL, .checksum_level = HG_CHECKSUM_NONE,            \

--- a/src/mercury_private.h
+++ b/src/mercury_private.h
@@ -16,6 +16,20 @@
 /* Public Type and Struct Definition */
 /*************************************/
 
+/* Previous versions of init info to keep compatiblity with older versions */
+struct hg_init_info_2_2 {
+    struct na_init_info na_init_info;
+    na_class_t *na_class;
+    hg_uint32_t request_post_init;
+    hg_uint32_t request_post_incr;
+    hg_bool_t auto_sm;
+    const char *sm_info_string;
+    hg_checksum_level_t checksum_level;
+    hg_bool_t no_bulk_eager;
+    hg_bool_t no_loopback;
+    hg_bool_t stats;
+};
+
 /* Private callback type after completion of operations */
 typedef void (*hg_core_completion_cb_t)(void *arg);
 
@@ -70,6 +84,13 @@ extern "C" {
 #endif
 
 /**
+ * Duplicate init info for ABI compatibility.
+ */
+static HG_INLINE void
+hg_init_info_dup_2_2(struct hg_init_info *hg_init_info,
+    const struct hg_init_info_2_2 *hg_init_info_2_2);
+
+/**
  * Increment bulk handle counter.
  */
 HG_PRIVATE void
@@ -112,6 +133,26 @@ hg_bulk_op_pool_create(hg_core_context_t *core_context, unsigned int init_count,
  */
 HG_PRIVATE void
 hg_bulk_op_pool_destroy(struct hg_bulk_op_pool *hg_bulk_op_pool);
+
+/*---------------------------------------------------------------------------*/
+static HG_INLINE void
+hg_init_info_dup_2_2(struct hg_init_info *hg_init_info,
+    const struct hg_init_info_2_2 *hg_init_info_2_2)
+{
+    *hg_init_info =
+        (struct hg_init_info){.na_init_info = hg_init_info_2_2->na_init_info,
+            .na_class = hg_init_info_2_2->na_class,
+            .request_post_init = hg_init_info_2_2->request_post_init,
+            .request_post_incr = hg_init_info_2_2->request_post_incr,
+            .auto_sm = hg_init_info_2_2->auto_sm,
+            .sm_info_string = hg_init_info_2_2->sm_info_string,
+            .checksum_level = hg_init_info_2_2->checksum_level,
+            .no_bulk_eager = hg_init_info_2_2->no_bulk_eager,
+            .no_loopback = hg_init_info_2_2->no_loopback,
+            .stats = hg_init_info_2_2->stats,
+            .no_multi_recv = HG_FALSE,
+            .release_input_early = HG_FALSE};
+}
 
 #ifdef __cplusplus
 }

--- a/src/na/na.h
+++ b/src/na/na.h
@@ -41,7 +41,7 @@ NA_PUBLIC void
 NA_Version_get(unsigned int *major, unsigned int *minor, unsigned int *patch);
 
 /**
- * Initialize the network NAion layer.
+ * Initialize the NA layer.
  * Must be finalized with NA_Finalize().
  *
  * \param info_string [IN]      host address with port number (e.g.,
@@ -55,7 +55,7 @@ NA_PUBLIC na_class_t *
 NA_Initialize(const char *info_string, bool listen) NA_WARN_UNUSED_RESULT;
 
 /**
- * Initialize the network NAion layer with options provided by init_info.
+ * Initialize the NA layer with options provided by init_info.
  * Must be finalized with NA_Finalize().
  *
  * \param info_string [IN]      host address with port number (e.g.,
@@ -71,7 +71,24 @@ NA_Initialize_opt(const char *info_string, bool listen,
     const struct na_init_info *na_init_info) NA_WARN_UNUSED_RESULT;
 
 /**
- * Finalize the network NAion layer.
+ * Initialize the NA layer with options provided by init_info.
+ * Must be finalized with NA_Finalize().
+ *
+ * \param info_string [IN]      host address with port number (e.g.,
+ *                              "tcp://localhost:3344" or
+ *                              "bmi+tcp://localhost:3344")
+ * \param listen [IN]           listen for incoming connections
+ * \param version [IN]          API version of the init info struct
+ * \param na_init_info [IN]     (Optional) NA init info, NULL if no info
+ *
+ * \return Pointer to NA class or NULL in case of failure
+ */
+NA_PUBLIC na_class_t *
+NA_Initialize_opt2(const char *info_string, bool listen, unsigned int version,
+    const struct na_init_info *na_init_info) NA_WARN_UNUSED_RESULT;
+
+/**
+ * Finalize the NA layer.
  *
  * \param na_class [IN/OUT]     pointer to NA class
  *

--- a/src/na/na_types.h
+++ b/src/na/na_types.h
@@ -45,9 +45,6 @@ enum na_mem_type {
 
 /* Init info */
 struct na_init_info {
-    /* Requested API version. */
-    uint32_t api_version;
-
     /* Preferred IP subnet to use. */
     const char *ip_subnet;
 
@@ -230,7 +227,6 @@ typedef void (*na_cb_t)(const struct na_cb_info *callback_info);
 #define NA_INIT_INFO_INITIALIZER                                               \
     (struct na_init_info)                                                      \
     {                                                                          \
-        .api_version = NA_VERSION(NA_VERSION_MAJOR, NA_VERSION_MINOR),         \
         .ip_subnet = NULL, .auth_key = NULL, .max_unexpected_size = 0,         \
         .max_expected_size = 0, .progress_mode = 0,                            \
         .addr_format = NA_ADDR_UNSPEC, .max_contexts = 1, .thread_mode = 0,    \


### PR DESCRIPTION
Add HG_Init_opt2() / NA_Initialize_opt2() routines and version info struct.