### PR TITLE
NA: add NA_Get_protocol_info() / NA_Free_protocol_info() (#544)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,11 @@ endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 #-----------------------------------------------------------------------------
+# Util
+#-----------------------------------------------------------------------------
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/util)
+
+#-----------------------------------------------------------------------------
 # Build doxygen documentation.
 #-----------------------------------------------------------------------------
 option(BUILD_DOCUMENTATION "Build documentation." OFF)

--- a/src/mercury.h
+++ b/src/mercury.h
@@ -59,6 +59,29 @@ HG_PUBLIC const char *
 HG_Error_to_string(hg_return_t errnum);
 
 /**
+ * Get information on protocols that are supported by underlying NA plugins. If
+ * \info_string is NULL, a list of all supported protocols by all plugins will
+ * be returned. The returned list must be freed using
+ * HG_Free_na_protocol_info().
+ *
+ * \param info_string [IN]          NULL or "<protocol>" or "<plugin+protocol>"
+ * \param na_protocol_info_p [OUT]  linked-list of protocol infos
+ *
+ * \return HG_SUCCESS or corresponding NA error code
+ */
+static HG_INLINE hg_return_t
+HG_Get_na_protocol_info(
+    const char *info_string, struct na_protocol_info **na_protocol_info_p);
+
+/**
+ * Free protocol info.
+ *
+ * \param na_protocol_info [IN/OUT] linked-list of protocol infos
+ */
+static HG_INLINE void
+HG_Free_na_protocol_info(struct na_protocol_info *na_protocol_info);
+
+/**
  * Initialize the Mercury layer.
  * Must be finalized with HG_Finalize().
  *
@@ -1039,6 +1062,21 @@ struct hg_handle {
     void *data;                         /* User data */
     void (*data_free_callback)(void *); /* User data free callback */
 };
+
+/*---------------------------------------------------------------------------*/
+static HG_INLINE hg_return_t
+HG_Get_na_protocol_info(
+    const char *info_string, struct na_protocol_info **na_protocol_info_p)
+{
+    return HG_Core_get_na_protocol_info(info_string, na_protocol_info_p);
+}
+
+/*---------------------------------------------------------------------------*/
+static HG_INLINE void
+HG_Free_na_protocol_info(struct na_protocol_info *na_protocol_info)
+{
+    HG_Core_free_na_protocol_info(na_protocol_info);
+}
 
 /*---------------------------------------------------------------------------*/
 static HG_INLINE const char *

--- a/src/mercury_core.c
+++ b/src/mercury_core.c
@@ -5467,6 +5467,21 @@ error:
 }
 
 /*---------------------------------------------------------------------------*/
+hg_return_t
+HG_Core_get_na_protocol_info(
+    const char *info_string, struct na_protocol_info **na_protocol_info_p)
+{
+    return (hg_return_t) NA_Get_protocol_info(info_string, na_protocol_info_p);
+}
+
+/*---------------------------------------------------------------------------*/
+void
+HG_Core_free_na_protocol_info(struct na_protocol_info *na_protocol_info)
+{
+    NA_Free_protocol_info(na_protocol_info);
+}
+
+/*---------------------------------------------------------------------------*/
 hg_core_class_t *
 HG_Core_init(const char *na_info_string, hg_bool_t na_listen)
 {

--- a/src/mercury_core.h
+++ b/src/mercury_core.h
@@ -84,6 +84,29 @@ extern "C" {
 #endif
 
 /**
+ * Get information on protocols that are supported by underlying NA plugins. If
+ * \info_string is NULL, a list of all supported protocols by all plugins will
+ * be returned. The returned list must be freed using
+ * HG_Core_free_na_protocol_info().
+ *
+ * \param info_string [IN]          NULL or "<protocol>" or "<plugin+protocol>"
+ * \param na_protocol_info_p [OUT]  linked-list of protocol infos
+ *
+ * \return HG_SUCCESS or corresponding NA error code
+ */
+HG_PUBLIC hg_return_t
+HG_Core_get_na_protocol_info(
+    const char *info_string, struct na_protocol_info **na_protocol_info_p);
+
+/**
+ * Free protocol info.
+ *
+ * \param na_protocol_info [IN/OUT] linked-list of protocol infos
+ */
+HG_PUBLIC void
+HG_Core_free_na_protocol_info(struct na_protocol_info *na_protocol_info);
+
+/**
  * Initialize the core Mercury layer.
  * Must be finalized with HG_Core_finalize().
  *

--- a/src/na/na.h
+++ b/src/na/na.h
@@ -41,6 +41,28 @@ NA_PUBLIC void
 NA_Version_get(unsigned int *major, unsigned int *minor, unsigned int *patch);
 
 /**
+ * Get information on protocols that are supported by underlying plugins. If
+ * \info_string is NULL, a list of all supported protocols by all plugins will
+ * be returned. The returned list must be freed using NA_Free_protocol_info().
+ *
+ * \param info_string [IN]          NULL or "<protocol>" or "<plugin+protocol>"
+ * \param na_protocol_info_p [OUT]  linked-list of protocol infos
+ *
+ * \return NA_SUCCESS or corresponding NA error code
+ */
+NA_PUBLIC na_return_t
+NA_Get_protocol_info(
+    const char *info_string, struct na_protocol_info **na_protocol_info_p);
+
+/**
+ * Free protocol info.
+ *
+ * \param na_protocol_info [IN/OUT] linked-list of protocol infos
+ */
+NA_PUBLIC void
+NA_Free_protocol_info(struct na_protocol_info *na_protocol_info);
+
+/**
  * Initialize the NA layer.
  * Must be finalized with NA_Finalize().
  *
@@ -937,6 +959,8 @@ struct na_context {
 /* NA plugin callbacks */
 struct na_class_ops {
     const char *class_name;
+    na_return_t (*get_protocol_info)(const struct na_info *na_info,
+        struct na_protocol_info **na_protocol_info_p);
     bool (*check_protocol)(const char *protocol_name);
     na_return_t (*initialize)(
         na_class_t *na_class, const struct na_info *na_info, bool listen);

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -443,6 +443,7 @@ na_bmi_cancel(na_class_t *na_class, na_context_t *context, na_op_id_t *op_id);
 
 const struct na_class_ops NA_PLUGIN_OPS(bmi) = {
     "bmi",                                /* name */
+    NULL,                                 /* get_protocol_info */
     na_bmi_check_protocol,                /* check_protocol */
     na_bmi_initialize,                    /* initialize */
     na_bmi_finalize,                      /* finalize */

--- a/src/na/na_cci.c
+++ b/src/na/na_cci.c
@@ -361,6 +361,7 @@ na_cci_cancel(na_class_t *na_class, na_context_t *context, na_op_id_t *op_id);
 
 const struct na_class_ops NA_PLUGIN_OPS(cci) = {
     "cci",                                /* name */
+    NULL,                                 /* get_protocol_info */
     na_cci_check_protocol,                /* check_protocol */
     na_cci_initialize,                    /* initialize */
     na_cci_finalize,                      /* finalize */

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -387,6 +387,7 @@ na_mpi_cancel(na_class_t *na_class, na_context_t *context, na_op_id_t *op_id);
 
 const struct na_class_ops NA_PLUGIN_OPS(mpi) = {
     "mpi",                                /* name */
+    NULL,                                 /* get_protocol_info */
     na_mpi_check_protocol,                /* check_protocol */
     na_mpi_initialize,                    /* initialize */
     na_mpi_finalize,                      /* finalize */

--- a/src/na/na_plugin.h
+++ b/src/na/na_plugin.h
@@ -130,6 +130,27 @@ NA_PLUGIN_VISIBILITY const char *
 na_cb_type_to_string(na_cb_type_t cb_type) NA_WARN_UNUSED_RESULT;
 
 /**
+ * Allocate protocol info entry.
+ *
+ * \param class_name [IN]       NA class name (e.g., ofi)
+ * \param protocol_name [IN]    protocol name (e.g., tcp)
+ * \param device_name [IN]      device name (e.g., eth0)
+ *
+ * \return Pointer to allocated entry or NULL in case of failure
+ */
+NA_PLUGIN_VISIBILITY struct na_protocol_info *
+na_protocol_info_alloc(const char *class_name, const char *protocol_name,
+    const char *device_name) NA_WARN_UNUSED_RESULT;
+
+/**
+ * Free protocol info entry.
+ *
+ * \param entry [IN/OUT]        pointer to protocol info entry
+ */
+NA_PLUGIN_VISIBILITY void
+na_protocol_info_free(struct na_protocol_info *entry);
+
+/**
  * Add callback to context completion queue.
  *
  * \param context [IN/OUT]              pointer to context of execution

--- a/src/na/na_psm.c
+++ b/src/na/na_psm.c
@@ -2615,6 +2615,7 @@ unlock_finish:
  */
 const struct na_class_ops NA_PSM_PLUGIN_VARIABLE = {
     NA_PSM_NAME,                           /* name */
+    NULL,                                  /* get_protocol_info */
     na_psm_check_protocol,                 /* check_protocol */
     na_psm_initialize,                     /* initialize */
     na_psm_finalize,                       /* finalize */

--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -889,6 +889,11 @@ na_sm_complete_signal(struct na_sm_class *na_sm_class);
 static NA_INLINE void
 na_sm_release(void *arg);
 
+/* get_protocol_info */
+static na_return_t
+na_sm_get_protocol_info(const struct na_info *na_info,
+    struct na_protocol_info **na_protocol_info_p);
+
 /* check_protocol */
 static bool
 na_sm_check_protocol(const char *protocol_name);
@@ -1078,6 +1083,7 @@ na_sm_cancel(na_class_t *na_class, na_context_t *context, na_op_id_t *op_id);
 
 const struct na_class_ops NA_PLUGIN_OPS(sm) = {
     "na",                              /* name */
+    na_sm_get_protocol_info,           /* get_protocol_info */
     na_sm_check_protocol,              /* check_protocol */
     na_sm_initialize,                  /* initialize */
     na_sm_finalize,                    /* finalize */
@@ -4238,6 +4244,30 @@ na_sm_release(void *arg)
 /* Plugin callbacks */
 /********************/
 
+static na_return_t
+na_sm_get_protocol_info(
+    const struct na_info *na_info, struct na_protocol_info **na_protocol_info_p)
+{
+    const char *protocol_name =
+        (na_info != NULL) ? na_info->protocol_name : NULL;
+    na_return_t ret;
+
+    if (protocol_name != NULL && strcmp(protocol_name, "sm")) {
+        *na_protocol_info_p = NULL;
+        return NA_SUCCESS;
+    }
+
+    *na_protocol_info_p = na_protocol_info_alloc("na", "sm", "shm");
+    NA_CHECK_SUBSYS_ERROR(cls, *na_protocol_info_p == NULL, error, ret,
+        NA_NOMEM, "Could not allocate protocol info entry");
+
+    return NA_SUCCESS;
+
+error:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
 static bool
 na_sm_check_protocol(const char *protocol_name)
 {

--- a/src/na/na_types.h
+++ b/src/na/na_types.h
@@ -91,6 +91,14 @@ struct na_segment {
     size_t len; /* Size of the segment in bytes */
 };
 
+/* NA protocol info */
+struct na_protocol_info {
+    struct na_protocol_info *next; /* Pointer to the next structure */
+    char *class_name;              /* Name of the class */
+    char *protocol_name;           /* Name of this protocol */
+    char *device_name;             /* Name of associated device */
+};
+
 /* Return codes:
  * Functions return 0 for success or corresponding return code */
 #define NA_RETURN_VALUES                                                       \

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Create executable
+#-----------------------------------------------------------------------------
+add_executable(hg_info info.c)
+target_link_libraries(hg_info mercury)
+mercury_set_exe_options(hg_info MERCURY)
+if(MERCURY_ENABLE_COVERAGE)
+  set_coverage_flags(hg_info)
+endif()
+
+#-----------------------------------------------------------------------------
+# Add Target(s) to CMake Install
+#-----------------------------------------------------------------------------
+install(
+  TARGETS
+    hg_info
+  RUNTIME DESTINATION ${MERCURY_INSTALL_BIN_DIR}
+)

--- a/util/info.c
+++ b/util/info.c
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2013-2022 UChicago Argonne, LLC and The HDF Group.
+ * Copyright (c) 2022-2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "mercury.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define NWIDTH 20
+
+/*---------------------------------------------------------------------------*/
+static hg_return_t
+print_info(const char *info_string)
+{
+    struct na_protocol_info *protocol_infos = NULL, *protocol_info;
+    hg_return_t ret;
+
+    ret = HG_Get_na_protocol_info(info_string, &protocol_infos);
+    if (ret != HG_SUCCESS) {
+        fprintf(stderr, "HG_Get_protocol_info() failed (%s)\n",
+            HG_Error_to_string(ret));
+        return ret;
+    }
+    if (protocol_infos == NULL) {
+        fprintf(stderr, "No protocol found for \"%s\"\n", info_string);
+        return HG_PROTONOSUPPORT;
+    }
+
+    printf("--------------------------------------------------\n");
+    printf("%-*s%*s%*s\n", 10, "Class", NWIDTH, "Protocol", NWIDTH, "Device");
+    printf("--------------------------------------------------\n");
+    for (protocol_info = protocol_infos; protocol_info != NULL;
+         protocol_info = protocol_info->next)
+        printf("%-*s%*s%*s\n", 10, protocol_info->class_name, NWIDTH,
+            protocol_info->protocol_name, NWIDTH, protocol_info->device_name);
+
+    HG_Free_na_protocol_info(protocol_infos);
+
+    return HG_SUCCESS;
+}
+
+/*---------------------------------------------------------------------------*/
+int
+main(int argc, char *argv[])
+{
+    const char *info_string = NULL;
+    hg_return_t hg_ret;
+
+    if (argc == 1) {
+        printf("Retrieving protocol info for all protocols...\n");
+    } else if (argc == 2) {
+        info_string = argv[1];
+        printf("Retrieving protocol info for \"%s\"...\n", info_string);
+    } else {
+        printf("usage: %s [<class+protocol>]\n", argv[0]);
+        goto err;
+    }
+
+    hg_ret = print_info(info_string);
+    if (hg_ret != HG_SUCCESS)
+        goto err;
+
+    return EXIT_SUCCESS;
+
+err:
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
This gives the ability to query protocol info from plugins

Refactor check protocol code for static/dynamic plugins

NA OFI/UCX/SM: add support for get_protocol_info

Add na_protocol_info struct to na_types

NA OFI: ensure extra caps passed are honored by provider

---
`NA_Get_protocol_info("ofi+tcp", &info)` will give for example `"ofi, tcp, lo" "ofi, tcp, eth0"` with the list of domains or doing
`NA_Get_protocol_info("tcp", &info)` will give `"ofi, tcp, lo" "ofi, tcp, eth0" "ucx, tcp, lo" "ucx, tcp, eth0"`
or passing `NULL` in `info_string`
`NA_Get_protocol_info(NULL, &info)` will give a list of all supported protocols and domains/devices