### PR TITLE
HG Core: separate internal list from user created list of handles

### DIFF
--- a/Testing/script/gh_install_deps.sh
+++ b/Testing/script/gh_install_deps.sh
@@ -10,7 +10,7 @@ if [[ $MERCURY_BUILD_CONFIGURATION == 'Debug' ]]; then
   OFI_EXTRA_FLAGS="--enable-debug"
 fi
 #OFI_PR=
-OFI_VERSION=1.18.1rc1
+OFI_VERSION=1.18.1
 
 # UCX
 if [[ $MERCURY_BUILD_CONFIGURATION == 'Tsan' ]]; then


### PR DESCRIPTION
Address an issue where HG_Context_unpost() would unnecessarily wait