### PR TITLE
HG perf: autodetect MPI implementation

### DIFF
--- a/Testing/common/CMakeLists.txt
+++ b/Testing/common/CMakeLists.txt
@@ -89,6 +89,7 @@ configure_file(
 set(NA_TEST_COMMON_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/na_test.c
   ${CMAKE_CURRENT_SOURCE_DIR}/na_test_getopt.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/na_test_mpi.c
 )
 
 set(MERCURY_TEST_COMMON_SRCS
@@ -109,6 +110,7 @@ set(NA_TEST_COMMON_PRIVATE_HEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/mercury_test_config.h
   ${CMAKE_CURRENT_SOURCE_DIR}/na_test.h
   ${CMAKE_CURRENT_SOURCE_DIR}/na_test_getopt.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/na_test_mpi.h
 )
 
 set(MERCURY_TEST_COMMON_PRIVATE_HEADERS

--- a/Testing/common/mercury_test.c
+++ b/Testing/common/mercury_test.c
@@ -248,26 +248,21 @@ HG_Test_init(int argc, char *argv[], struct hg_test_info *hg_test_info)
     hg_test_info->hg_class = hg_test_info->hg_classes[0]; /* default */
 
     if (hg_test_info->na_test_info.listen) {
-#ifdef HG_TEST_HAS_PARALLEL
         int j;
-        for (j = 0; j < hg_test_info->na_test_info.mpi_comm_size; j++) {
-            if (hg_test_info->na_test_info.mpi_comm_rank == j) {
-#endif
+        for (j = 0; j < hg_test_info->na_test_info.mpi_info.size; j++) {
+            if (hg_test_info->na_test_info.mpi_info.rank == j) {
                 for (i = 0; i < hg_test_info->na_test_info.max_classes; i++) {
                     ret = hg_test_self_addr_publish(hg_test_info->hg_classes[i],
-                        i > 0 || hg_test_info->na_test_info.mpi_comm_rank != 0);
+                        i > 0 || hg_test_info->na_test_info.mpi_info.rank != 0);
                     HG_TEST_CHECK_HG_ERROR(
                         error, ret, "hg_test_self_addr_publish() failed");
                 }
-
-#ifdef HG_TEST_HAS_PARALLEL
             }
             NA_Test_barrier(&hg_test_info->na_test_info);
         }
         /* If static client, must wait for server to write config file */
         if (hg_test_info->na_test_info.mpi_static)
-            MPI_Barrier(MPI_COMM_WORLD);
-#endif
+            na_test_mpi_barrier_world();
     }
 
     return HG_SUCCESS;

--- a/Testing/common/na_test.h
+++ b/Testing/common/na_test.h
@@ -8,12 +8,7 @@
 #ifndef NA_TEST_H
 #define NA_TEST_H
 
-#include "mercury_test_config.h"
-#include "na.h"
-
-#ifdef HG_TEST_HAS_PARALLEL
-#    include <mpi.h>
-#endif
+#include "na_test_mpi.h"
 
 /*************************************/
 /* Public Type and Struct Definition */
@@ -43,13 +38,7 @@ struct na_test_info {
     size_t buf_size_max;     /* Max buffer size */
     size_t buf_count;        /* Buffer count */
     bool verbose;            /* Verbose mode */
-    int max_number_of_peers; /* Max number of peers */
-#ifdef HG_TEST_HAS_PARALLEL
-    MPI_Comm mpi_comm;    /* MPI comm */
-    bool mpi_no_finalize; /* Prevent from finalizing MPI */
-#endif
-    int mpi_comm_rank;   /* MPI comm rank */
-    int mpi_comm_size;   /* MPI comm size */
+    struct na_test_mpi_info mpi_info;
     bool extern_init;    /* Extern init */
     bool use_threads;    /* Use threads */
     bool force_register; /* Force registration each iteration */
@@ -216,7 +205,7 @@ NA_Test_barrier(const struct na_test_info *na_test_info);
  */
 void
 NA_Test_bcast(
-    char *buf, int count, int root, const struct na_test_info *na_test_info);
+    void *buf, size_t size, int root, const struct na_test_info *na_test_info);
 
 #ifdef __cplusplus
 }

--- a/Testing/common/na_test_mpi.c
+++ b/Testing/common/na_test_mpi.c
@@ -1,0 +1,629 @@
+/**
+ * Copyright (c) 2013-2022 UChicago Argonne, LLC and The HDF Group.
+ * Copyright (c) 2022-2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "na_test.h"
+
+#ifdef HG_TEST_HAS_PARALLEL
+#    ifdef NA_HAS_MPI
+#        include "na_mpi.h"
+#    endif
+#else
+#    include "mercury_dl.h"
+#    define MPI_SUCCESS         0
+#    define MPI_THREAD_MULTIPLE 3
+#endif
+
+#include "mercury_util.h"
+
+/****************/
+/* Local Macros */
+/****************/
+
+/************************************/
+/* Local Type and Struct Definition */
+/************************************/
+
+enum na_test_mpi_impl {
+    NA_TEST_MPI_NONE,
+#ifdef HG_TEST_HAS_PARALLEL
+    NA_TEST_MPI_SYSTEM,
+#else
+    NA_TEST_MPI_MPICH,
+    NA_TEST_MPI_OMPI
+#endif
+};
+
+union na_test_mpi_dtype {
+#ifdef HG_TEST_HAS_PARALLEL
+    MPI_Datatype sys;
+#else
+    void *ompi;
+    int mpich;
+#endif
+};
+
+#ifdef HG_TEST_HAS_PARALLEL
+#    define NA_TEST_MPI_SYMS                                                   \
+        X(Init, (int *argc, char ***argv))                                     \
+        X(Init_thread, (int *argc, char ***argv, int required, int *provided)) \
+        X(Finalize, (void) )                                                   \
+        X(Initialized, (int *flag))                                            \
+        X(Finalized, (int *flag))                                              \
+        X(Comm_size, (MPI_Comm comm, int *size))                               \
+        X(Comm_rank, (MPI_Comm comm, int *rank))                               \
+        X(Comm_split, (MPI_Comm comm, int color, int key, MPI_Comm *newcomm))  \
+        X(Comm_dup, (MPI_Comm comm, MPI_Comm * newcomm))                       \
+        X(Comm_free, (MPI_Comm * comm))                                        \
+        X(Barrier, (MPI_Comm comm))                                            \
+        X(Bcast, (void *buffer, int count, MPI_Datatype datatype, int root,    \
+                     MPI_Comm comm))
+
+#    define X(a, b) int(*a) b;
+struct na_test_mpi_funcs {
+    NA_TEST_MPI_SYMS
+};
+#    undef X
+
+#    define X(a, b) .a = MPI_##a,
+static struct na_test_mpi_funcs na_test_mpi_funcs = {NA_TEST_MPI_SYMS};
+#    undef X
+#else
+#    define NA_TEST_MPICH_SYMS                                                 \
+        X(Init, (int *argc, char ***argv))                                     \
+        X(Init_thread, (int *argc, char ***argv, int required, int *provided)) \
+        X(Finalize, (void) )                                                   \
+        X(Initialized, (int *flag))                                            \
+        X(Finalized, (int *flag))                                              \
+        X(Comm_size, (int comm, int *size))                                    \
+        X(Comm_rank, (int comm, int *rank))                                    \
+        X(Comm_split, (int comm, int color, int key, int *newcomm))            \
+        X(Comm_dup, (int comm, int *newcomm))                                  \
+        X(Comm_free, (int *comm))                                              \
+        X(Barrier, (int comm))                                                 \
+        X(Bcast, (void *buffer, int count, int datatype, int root, int comm))
+
+#    define NA_TEST_OMPI_SYMS                                                  \
+        X(Init, (int *argc, char ***argv))                                     \
+        X(Init_thread, (int *argc, char ***argv, int required, int *provided)) \
+        X(Finalize, (void) )                                                   \
+        X(Initialized, (int *flag))                                            \
+        X(Finalized, (int *flag))                                              \
+        X(Comm_size, (void *comm, int *size))                                  \
+        X(Comm_rank, (void *comm, int *rank))                                  \
+        X(Comm_split, (void *comm, int color, int key, void **newcomm))        \
+        X(Comm_dup, (void *comm, void **newcomm))                              \
+        X(Comm_free, (void **comm))                                            \
+        X(Barrier, (void *comm))                                               \
+        X(Bcast,                                                               \
+            (void *buffer, int count, void *datatype, int root, void *comm))
+
+#    define X(a, b) int(*a) b;
+struct na_test_mpich_funcs {
+    NA_TEST_MPICH_SYMS
+};
+struct na_test_ompi_funcs {
+    NA_TEST_OMPI_SYMS
+};
+#    undef X
+
+#    define X(a, b) .a = NULL,
+static struct na_test_mpich_funcs na_test_mpich_funcs = {NA_TEST_MPICH_SYMS};
+static struct na_test_ompi_funcs na_test_ompi_funcs = {NA_TEST_OMPI_SYMS};
+#    undef X
+
+static const char *const na_test_mpi_lib_names[] = {
+    "libmpi.so", "libmpi.so.12", "libmpi.so.40", NULL};
+#endif
+
+/********************/
+/* Local Prototypes */
+/********************/
+
+#ifndef HG_TEST_HAS_PARALLEL
+static void
+na_test_mpi_init_lib(void) HG_ATTR_CONSTRUCTOR;
+#endif
+
+/*******************/
+/* Local Variables */
+/*******************/
+
+#ifdef HG_TEST_HAS_PARALLEL
+static enum na_test_mpi_impl na_test_mpi_impl = NA_TEST_MPI_SYSTEM;
+
+static union na_test_mpi_comm na_test_mpi_comm_world = {.sys = MPI_COMM_WORLD};
+static union na_test_mpi_dtype na_test_mpi_byte = {.sys = MPI_BYTE};
+#else
+static enum na_test_mpi_impl na_test_mpi_impl = NA_TEST_MPI_NONE;
+
+/* MPICH constants */
+static int na_test_mpich_comm_world = (int) 0x44000000;
+static int na_test_mpich_byte = (int) 0x4c00010d;
+
+/* OMPI constants */
+static void *na_test_ompi_comm_world = NULL;
+static void *na_test_ompi_byte = NULL;
+
+static union na_test_mpi_comm na_test_mpi_comm_world;
+static union na_test_mpi_dtype na_test_mpi_byte;
+
+static void
+na_test_mpi_init_lib(void)
+{
+    HG_DL_HANDLE dl_handle = NULL;
+    int i;
+
+    for (i = 0; dl_handle == NULL && na_test_mpi_lib_names[i] != NULL; i++)
+        dl_handle = hg_dl_open(na_test_mpi_lib_names[i]);
+    NA_TEST_CHECK_ERROR_NORET(
+        dl_handle == NULL, error, "Could not find libmpi.so");
+
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wpedantic"
+
+    /* Look for openmpi comm world */
+    na_test_ompi_comm_world = hg_dl_sym(dl_handle, "ompi_mpi_comm_world");
+    if (na_test_ompi_comm_world != NULL) {
+        na_test_ompi_byte = hg_dl_sym(dl_handle, "ompi_mpi_byte");
+        NA_TEST_CHECK_ERROR_NORET(
+            na_test_ompi_byte == NULL, error, "Could not find MPI_BYTE");
+
+#    define X(a, b)                                                            \
+        na_test_ompi_funcs.a = hg_dl_sym(dl_handle, "MPI_" #a);                \
+        NA_TEST_CHECK_ERROR_NORET(                                             \
+            na_test_ompi_funcs.a == NULL, error, "Could not find MPI_" #a);
+        do {
+            NA_TEST_OMPI_SYMS
+        } while (0);
+#    undef X
+
+        na_test_mpi_impl = NA_TEST_MPI_OMPI;
+        na_test_mpi_comm_world.ompi = na_test_ompi_comm_world;
+        na_test_mpi_byte.ompi = na_test_ompi_byte;
+    } else {
+#    define X(a, b)                                                            \
+        na_test_mpich_funcs.a = hg_dl_sym(dl_handle, "MPI_" #a);               \
+        NA_TEST_CHECK_ERROR_NORET(                                             \
+            na_test_mpich_funcs.a == NULL, error, "Could not find MPI_" #a);
+        do {
+            NA_TEST_MPICH_SYMS
+        } while (0);
+#    undef X
+
+        na_test_mpi_impl = NA_TEST_MPI_MPICH;
+        na_test_mpi_comm_world.mpich = na_test_mpich_comm_world;
+        na_test_mpi_byte.mpich = na_test_mpich_byte;
+    }
+
+#    pragma GCC diagnostic pop
+
+    return;
+
+error:
+    printf("Could not find mpi\n");
+    return;
+}
+#endif
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Init(int *argc, char ***argv)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Init(argc, argv);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Init(argc, argv);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Init(argc, argv);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Init_thread(int *argc, char ***argv, int required, int *provided)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Init_thread(
+                argc, argv, required, provided);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Init_thread(
+                argc, argv, required, provided);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Init_thread(
+                argc, argv, required, provided);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Finalize(void)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Finalize();
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Finalize();
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Finalize();
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Initialized(int *flag)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Initialized(flag);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Initialized(flag);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Initialized(flag);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Finalized(int *flag)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Finalized(flag);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Finalized(flag);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Finalized(flag);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Comm_size(const union na_test_mpi_comm *comm, int *size)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Comm_size(comm->sys, size);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Comm_size(comm->mpich, size);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Comm_size(comm->ompi, size);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Comm_rank(const union na_test_mpi_comm *comm, int *rank)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Comm_rank(comm->sys, rank);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Comm_rank(comm->mpich, rank);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Comm_rank(comm->ompi, rank);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Comm_split(const union na_test_mpi_comm *comm, int color, int key,
+    union na_test_mpi_comm *newcomm)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Comm_split(
+                comm->sys, color, key, &newcomm->sys);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Comm_split(
+                comm->mpich, color, key, &newcomm->mpich);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Comm_split(
+                comm->ompi, color, key, &newcomm->ompi);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Comm_dup(
+    const union na_test_mpi_comm *comm, union na_test_mpi_comm *newcomm)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Comm_dup(comm->sys, &newcomm->sys);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Comm_dup(comm->mpich, &newcomm->mpich);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Comm_dup(comm->ompi, &newcomm->ompi);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Comm_free(union na_test_mpi_comm *comm)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Comm_free(&comm->sys);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Comm_free(&comm->mpich);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Comm_free(&comm->ompi);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Barrier(const union na_test_mpi_comm *comm)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Barrier(comm->sys);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Barrier(comm->mpich);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Barrier(comm->ompi);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+static int
+na_test_mpi_Bcast(void *buffer, int count,
+    const union na_test_mpi_dtype *datatype, int root,
+    const union na_test_mpi_comm *comm)
+{
+    switch (na_test_mpi_impl) {
+#ifdef HG_TEST_HAS_PARALLEL
+        case NA_TEST_MPI_SYSTEM:
+            return na_test_mpi_funcs.Bcast(
+                buffer, count, datatype->sys, root, comm->sys);
+#else
+        case NA_TEST_MPI_MPICH:
+            return na_test_mpich_funcs.Bcast(
+                buffer, count, datatype->mpich, root, comm->mpich);
+        case NA_TEST_MPI_OMPI:
+            return na_test_ompi_funcs.Bcast(
+                buffer, count, datatype->ompi, root, comm->ompi);
+#endif
+        case NA_TEST_MPI_NONE:
+        default:
+            return -1;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
+na_test_mpi_init(struct na_test_mpi_info *mpi_info, bool listen,
+    bool use_threads, bool mpi_static)
+{
+    int mpi_initialized = 0;
+    na_return_t ret;
+    int rc;
+
+    /* Silently exit if MPI is not detected */
+    if (na_test_mpi_impl == NA_TEST_MPI_NONE) {
+        mpi_info->size = 1;
+        mpi_info->rank = 0;
+        mpi_info->mpi_no_finalize = true;
+
+        return NA_SUCCESS;
+    }
+
+    rc = na_test_mpi_Initialized(&mpi_initialized);
+    NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+        "MPI_Initialized() failed");
+    NA_TEST_CHECK_ERROR(mpi_initialized, error, ret, NA_PROTOCOL_ERROR,
+        "MPI was already initialized");
+
+#ifdef NA_MPI_HAS_GNI_SETUP
+    /* Setup GNI job before initializing MPI */
+    ret = NA_MPI_Gni_job_setup();
+    NA_TEST_CHECK_NA_ERROR(error, ret, "Could not setup GNI job");
+#endif
+
+    if ((listen && use_threads) || mpi_static) {
+        int provided;
+
+        rc =
+            na_test_mpi_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided);
+        NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+            "MPI_Init_thread() failed");
+
+        NA_TEST_CHECK_ERROR(provided != MPI_THREAD_MULTIPLE, error, ret,
+            NA_PROTOCOL_ERROR, "MPI_THREAD_MULTIPLE cannot be set");
+
+        /* Only if we do static MPMD MPI */
+        if (mpi_static) {
+            int color, global_rank;
+
+            rc = na_test_mpi_Comm_rank(&na_test_mpi_comm_world, &global_rank);
+            NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret,
+                NA_PROTOCOL_ERROR, "MPI_Comm_rank() failed");
+
+            /* Color is 1 for server, 2 for client */
+            color = listen ? 1 : 2;
+
+            /* Assume that the application did not split MPI_COMM_WORLD
+             * already
+             */
+            rc = na_test_mpi_Comm_split(
+                &na_test_mpi_comm_world, color, global_rank, &mpi_info->comm);
+            NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret,
+                NA_PROTOCOL_ERROR, "MPI_Comm_split() failed");
+
+#ifdef NA_HAS_MPI /* implies HG_TEST_HAS_PARALLEL */
+            /* Set init comm that will be used to setup NA MPI */
+            NA_MPI_Set_init_intra_comm(mpi_info->comm.sys);
+#endif
+        } else {
+            rc = na_test_mpi_Comm_dup(&na_test_mpi_comm_world, &mpi_info->comm);
+            NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret,
+                NA_PROTOCOL_ERROR, "MPI_Comm_dup() failed");
+        }
+    } else {
+        rc = na_test_mpi_Init(NULL, NULL);
+        NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+            "MPI_Init() failed");
+
+        rc = na_test_mpi_Comm_dup(&na_test_mpi_comm_world, &mpi_info->comm);
+        NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+            "MPI_Comm_dup() failed");
+    }
+
+    rc = na_test_mpi_Comm_rank(&mpi_info->comm, &mpi_info->rank);
+    NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+        "MPI_Comm_rank() failed");
+
+    rc = na_test_mpi_Comm_size(&mpi_info->comm, &mpi_info->size);
+    NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+        "MPI_Comm_size() failed");
+
+    return NA_SUCCESS;
+
+error:
+    na_test_mpi_finalize(mpi_info);
+
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+na_test_mpi_finalize(struct na_test_mpi_info *mpi_info)
+{
+    int mpi_finalized = 0;
+
+    if (mpi_info->mpi_no_finalize)
+        return;
+
+    (void) na_test_mpi_Finalized(&mpi_finalized);
+    if (mpi_finalized)
+        return;
+
+    (void) na_test_mpi_Comm_free(&mpi_info->comm);
+
+    (void) na_test_mpi_Finalize();
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
+na_test_mpi_barrier(const struct na_test_mpi_info *mpi_info)
+{
+    na_return_t ret;
+    int rc;
+
+    rc = na_test_mpi_Barrier(&mpi_info->comm);
+    NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+        "MPI_Barrier() failed");
+
+    return NA_SUCCESS;
+
+error:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
+na_test_mpi_barrier_world(void)
+{
+    na_return_t ret;
+    int rc;
+
+    rc = na_test_mpi_Barrier(&na_test_mpi_comm_world);
+    NA_TEST_CHECK_ERROR(rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR,
+        "MPI_Barrier() failed");
+
+    return NA_SUCCESS;
+
+error:
+    return ret;
+}
+
+/*---------------------------------------------------------------------------*/
+na_return_t
+na_test_mpi_bcast(const struct na_test_mpi_info *mpi_info, void *buffer,
+    size_t size, int root)
+{
+    na_return_t ret;
+    int rc;
+
+    rc = na_test_mpi_Bcast(
+        buffer, (int) size, &na_test_mpi_byte, root, &mpi_info->comm);
+    NA_TEST_CHECK_ERROR(
+        rc != MPI_SUCCESS, error, ret, NA_PROTOCOL_ERROR, "MPI_Bcast() failed");
+
+    return NA_SUCCESS;
+
+error:
+    return ret;
+}

--- a/Testing/common/na_test_mpi.h
+++ b/Testing/common/na_test_mpi.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2013-2022 UChicago Argonne, LLC and The HDF Group.
+ * Copyright (c) 2022-2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef NA_TEST_MPI_H
+#define NA_TEST_MPI_H
+
+#include "mercury_test_config.h"
+#include "na.h"
+
+#ifdef HG_TEST_HAS_PARALLEL
+#    include <mpi.h>
+#endif
+
+/*************************************/
+/* Public Type and Struct Definition */
+/*************************************/
+
+union na_test_mpi_comm {
+#ifdef HG_TEST_HAS_PARALLEL
+    MPI_Comm sys;
+#else
+    void *ompi;
+    int mpich;
+#endif
+};
+
+struct na_test_mpi_info {
+    union na_test_mpi_comm comm; /* MPI comm */
+    int rank;                    /* MPI comm rank */
+    int size;                    /* MPI comm size */
+    bool mpi_no_finalize;        /* Prevent from finalizing MPI */
+};
+
+/*****************/
+/* Public Macros */
+/*****************/
+
+/*********************/
+/* Public Prototypes */
+/*********************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+na_return_t
+na_test_mpi_init(struct na_test_mpi_info *mpi_info, bool listen,
+    bool use_threads, bool mpi_static);
+
+void
+na_test_mpi_finalize(struct na_test_mpi_info *mpi_info);
+
+na_return_t
+na_test_mpi_barrier(const struct na_test_mpi_info *mpi_info);
+
+na_return_t
+na_test_mpi_barrier_world(void);
+
+na_return_t
+na_test_mpi_bcast(const struct na_test_mpi_info *mpi_info, void *buffer,
+    size_t size, int root);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NA_TEST_MPI_H */

--- a/Testing/perf/hg/hg_bw_read.c
+++ b/Testing/perf/hg/hg_bw_read.c
@@ -33,8 +33,8 @@ static hg_return_t
 hg_perf_run(const struct hg_test_info *hg_test_info,
     struct hg_perf_class_info *info, size_t buf_size, size_t skip)
 {
-    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_comm_rank,
-           comm_size = (size_t) hg_test_info->na_test_info.mpi_comm_size,
+    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_info.rank,
+           comm_size = (size_t) hg_test_info->na_test_info.mpi_info.size,
            loop = (size_t) hg_test_info->na_test_info.loop;
     hg_time_t t1, t2;
     hg_return_t ret;
@@ -128,7 +128,7 @@ main(int argc, char *argv[])
         HG_Error_to_string(hg_ret));
 
     /* Header info */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_print_header_bw(hg_test_info, info, BENCHMARK_NAME);
 
     /* Bulk RPC with different sizes */
@@ -142,7 +142,7 @@ main(int argc, char *argv[])
     }
 
     /* Finalize interface */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_send_done(info);
 
     hg_perf_cleanup(&perf_info);

--- a/Testing/perf/hg/hg_bw_write.c
+++ b/Testing/perf/hg/hg_bw_write.c
@@ -33,8 +33,8 @@ static hg_return_t
 hg_perf_run(const struct hg_test_info *hg_test_info,
     struct hg_perf_class_info *info, size_t buf_size, size_t skip)
 {
-    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_comm_rank,
-           comm_size = (size_t) hg_test_info->na_test_info.mpi_comm_size,
+    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_info.rank,
+           comm_size = (size_t) hg_test_info->na_test_info.mpi_info.size,
            loop = (size_t) hg_test_info->na_test_info.loop;
     hg_time_t t1, t2;
     hg_return_t ret;
@@ -114,7 +114,7 @@ main(int argc, char *argv[])
         HG_Error_to_string(hg_ret));
 
     /* Header info */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_print_header_bw(hg_test_info, info, BENCHMARK_NAME);
 
     /* Bulk RPC with different sizes */
@@ -128,7 +128,7 @@ main(int argc, char *argv[])
     }
 
     /* Finalize interface */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_send_done(info);
 
     hg_perf_cleanup(&perf_info);

--- a/Testing/perf/hg/hg_perf_server.c
+++ b/Testing/perf/hg/hg_perf_server.c
@@ -151,8 +151,11 @@ main(int argc, char *argv[])
     HG_TEST_CHECK_HG_ERROR(error, hg_ret, "hg_perf_init() failed (%s)",
         HG_Error_to_string(hg_ret));
     hg_test_info = &info.hg_test_info;
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
+        printf("# %d server process(es)\n",
+            hg_test_info->na_test_info.mpi_info.size);
 
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         HG_TEST_READY_MSG();
 
     if (info.class_max > 1) {
@@ -179,7 +182,7 @@ main(int argc, char *argv[])
     }
 
     /* Finalize interface */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         printf("Finalizing...\n");
     hg_perf_cleanup(&info);
     free(progress_threads);

--- a/Testing/perf/hg/hg_rate.c
+++ b/Testing/perf/hg/hg_rate.c
@@ -58,7 +58,7 @@ hg_perf_run(const struct hg_test_info *hg_test_info,
         unsigned int j;
 
         if (i == skip) {
-            if (hg_test_info->na_test_info.mpi_comm_size > 1)
+            if (hg_test_info->na_test_info.mpi_info.size > 1)
                 NA_Test_barrier(&hg_test_info->na_test_info);
             hg_time_get_current(&t1);
         }
@@ -93,12 +93,12 @@ hg_perf_run(const struct hg_test_info *hg_test_info,
         }
     }
 
-    if (hg_test_info->na_test_info.mpi_comm_size > 1)
+    if (hg_test_info->na_test_info.mpi_info.size > 1)
         NA_Test_barrier(&hg_test_info->na_test_info);
 
     hg_time_get_current(&t2);
 
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_print_lat(
             hg_test_info, info, buf_size, hg_time_subtract(t2, t1));
 
@@ -136,7 +136,7 @@ main(int argc, char *argv[])
         HG_Error_to_string(hg_ret));
 
     /* Header info */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_print_header_lat(hg_test_info, info, BENCHMARK_NAME);
 
     /* NULL RPC */
@@ -157,7 +157,7 @@ main(int argc, char *argv[])
     }
 
     /* Finalize interface */
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0)
+    if (hg_test_info->na_test_info.mpi_info.rank == 0)
         hg_perf_send_done(info);
 
     hg_perf_cleanup(&perf_info);

--- a/Testing/perf/hg/mercury_perf.c
+++ b/Testing/perf/hg/mercury_perf.c
@@ -467,8 +467,8 @@ hg_return_t
 hg_perf_set_handles(const struct hg_test_info *hg_test_info,
     struct hg_perf_class_info *info, enum hg_perf_rpc_id rpc_id)
 {
-    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_comm_rank,
-           comm_size = (size_t) hg_test_info->na_test_info.mpi_comm_size;
+    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_info.rank,
+           comm_size = (size_t) hg_test_info->na_test_info.mpi_info.size;
     hg_return_t ret;
     size_t i;
 
@@ -517,7 +517,7 @@ hg_perf_rpc_buf_init(
 
     barrier = true;
 
-    if (hg_test_info->na_test_info.mpi_comm_rank == 0) {
+    if (hg_test_info->na_test_info.mpi_info.rank == 0) {
         size_t i;
 
         for (i = 0; i < info->target_addr_max; i++) {
@@ -576,8 +576,8 @@ hg_return_t
 hg_perf_bulk_buf_init(const struct hg_test_info *hg_test_info,
     struct hg_perf_class_info *info, hg_bulk_op_t bulk_op)
 {
-    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_comm_rank,
-           comm_size = (size_t) hg_test_info->na_test_info.mpi_comm_size;
+    size_t comm_rank = (size_t) hg_test_info->na_test_info.mpi_info.rank,
+           comm_size = (size_t) hg_test_info->na_test_info.mpi_info.size;
     hg_uint8_t bulk_flags =
         (bulk_op == HG_BULK_PULL) ? HG_BULK_READ_ONLY : HG_BULK_WRITE_ONLY;
     struct hg_perf_request args = {.expected_count = (int32_t) info->handle_max,
@@ -681,11 +681,13 @@ hg_perf_print_header_lat(const struct hg_test_info *hg_test_info,
     const struct hg_perf_class_info *info, const char *benchmark)
 {
     printf("# %s v%s\n", benchmark, VERSION_NAME);
+    printf(
+        "# %d client process(es)\n", hg_test_info->na_test_info.mpi_info.size);
     printf("# Loop %d times from size %zu to %zu byte(s) with %zu handle(s) "
            "in-flight\n",
         hg_test_info->na_test_info.loop, info->buf_size_min, info->buf_size_max,
         info->handle_max);
-    if (info->handle_max * (size_t) hg_test_info->na_test_info.mpi_comm_size <
+    if (info->handle_max * (size_t) hg_test_info->na_test_info.mpi_info.size <
         info->target_addr_max)
         printf("# WARNING number of handles in flight less than number of "
                "targets\n");
@@ -705,7 +707,7 @@ hg_perf_print_lat(const struct hg_test_info *hg_test_info,
     size_t loop = (size_t) hg_test_info->na_test_info.loop,
            handle_max = (size_t) info->handle_max,
            dir = (size_t) (hg_test_info->bidirectional ? 2 : 1),
-           mpi_comm_size = (size_t) hg_test_info->na_test_info.mpi_comm_size;
+           mpi_comm_size = (size_t) hg_test_info->na_test_info.mpi_info.size;
 
     rpc_time = hg_time_to_double(t) * 1e6 /
                (double) (loop * handle_max * dir * mpi_comm_size);
@@ -720,6 +722,8 @@ hg_perf_print_header_bw(const struct hg_test_info *hg_test_info,
     const struct hg_perf_class_info *info, const char *benchmark)
 {
     printf("# %s v%s\n", benchmark, VERSION_NAME);
+    printf(
+        "# %d client process(es)\n", hg_test_info->na_test_info.mpi_info.size);
     printf("# Loop %d times from size %zu to %zu byte(s) with %zu handle(s) "
            "in-flight\n# - %zu bulk transfer(s) per handle\n",
         hg_test_info->na_test_info.loop, info->buf_size_min, info->buf_size_max,
@@ -741,7 +745,7 @@ hg_perf_print_bw(const struct hg_test_info *hg_test_info,
     const struct hg_perf_class_info *info, size_t buf_size, hg_time_t t)
 {
     size_t loop = (size_t) hg_test_info->na_test_info.loop,
-           mpi_comm_size = (size_t) hg_test_info->na_test_info.mpi_comm_size,
+           mpi_comm_size = (size_t) hg_test_info->na_test_info.mpi_info.size,
            handle_max = (size_t) info->handle_max,
            buf_count = (size_t) info->bulk_count;
     double avg_time, avg_bw;

--- a/Testing/perf/na/na_perf.c
+++ b/Testing/perf/na/na_perf.c
@@ -125,7 +125,7 @@ na_perf_init(int argc, char *argv[], bool listen, struct na_perf_info *info)
     info->na_class = info->na_test_info.na_class;
 
     /* Parallel is not supported */
-    NA_TEST_CHECK_ERROR(info->na_test_info.mpi_comm_size > 1, error, ret,
+    NA_TEST_CHECK_ERROR(info->na_test_info.mpi_info.size > 1, error, ret,
         NA_OPNOTSUPPORTED, "Not a parallel test");
 
     /* Multi-recv */

--- a/Testing/script/gh_script.cmake
+++ b/Testing/script/gh_script.cmake
@@ -78,6 +78,7 @@ else()
   # Disable sockets with Tsan builds (OFI issues)
   if(MERCURY_BUILD_CONFIGURATION MATCHES "Tsan")
     set(OFI_PROTOCOLS "tcp;tcp_rxm")
+    set(ENV{FI_PROVIDER} "tcp") # ensure MPI uses tcp
   else()
     set(OFI_PROTOCOLS "sockets;tcp;tcp_rxm")
   endif()

--- a/Testing/unit/hg/mercury_unit.c
+++ b/Testing/unit/hg/mercury_unit.c
@@ -413,7 +413,7 @@ hg_unit_cleanup(struct hg_unit_info *info)
 
     /* Client sends request to terminate server */
     if (!info->hg_test_info.na_test_info.listen) {
-        if (info->hg_test_info.na_test_info.mpi_comm_rank == 0) {
+        if (info->hg_test_info.na_test_info.mpi_info.rank == 0) {
             hg_uint8_t i, context_count = max_contexts ? max_contexts : 1;
             for (i = 0; i < context_count; i++)
                 hg_test_finalize_rpc(info, i);


### PR DESCRIPTION
MPI can now be autodetected and dynamically loaded, even if MERCURY_TESTING_ENABLE_PARALLEL was turned off. If MERCURY_TESTING_ENABLE_PARALLEL is turned on, tests remain linked against MPI as they used to be.

Add client and server comm size information.