### PR TITLE
NA OFI: add support for FI_AV_AUTH_KEY

### DIFF
--- a/Testing/common/CMake/FindCXI.cmake
+++ b/Testing/common/CMake/FindCXI.cmake
@@ -1,0 +1,25 @@
+# - Try to find CXI
+# Once done this will define
+#  CXI_FOUND - System has CXI
+#  CXI_INCLUDE_DIRS - The CXI include directories
+#  CXI_LIBRARIES - The libraries needed to use CXI
+
+find_package(PkgConfig)
+pkg_check_modules(PC_CXI libcxi)
+
+find_path(CXI_INCLUDE_DIR libcxi/libcxi.h
+  HINTS ${PC_CXI_INCLUDEDIR} ${PC_CXI_INCLUDE_DIRS})
+
+find_library(CXI_LIBRARY NAMES cxi
+  HINTS ${PC_CXI_LIBDIR} ${PC_CXI_LIBRARY_DIRS})
+
+set(CXI_INCLUDE_DIRS ${CXI_INCLUDE_DIR})
+set(CXI_LIBRARIES ${CXI_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CXI_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(CXI DEFAULT_MSG
+                                  CXI_INCLUDE_DIR CXI_LIBRARY)
+
+mark_as_advanced(CXI_INCLUDE_DIR CXI_LIBRARY)

--- a/Testing/common/CMakeLists.txt
+++ b/Testing/common/CMakeLists.txt
@@ -47,6 +47,26 @@ mark_as_advanced(MERCURY_TESTING_ENABLE_PARALLEL)
 # Detect <sys/prctl.h>
 check_include_files("sys/prctl.h" HG_TEST_HAS_SYSPRCTL_H)
 
+# CXI
+if(NA_USE_OFI)
+  option(NA_OFI_TESTING_USE_CXI
+    "Use CXI library for service configuration." OFF)
+  mark_as_advanced(NA_OFI_TESTING_USE_CXI)
+  if(NA_OFI_TESTING_USE_CXI)
+    find_package(CXI REQUIRED)
+    message(STATUS "CXI include directory: ${CXI_INCLUDE_DIRS}")
+    set(HG_TEST_HAS_CXI 1)
+    set(NA_TEST_COMMON_EXT_INCLUDE_DEPENDENCIES
+      ${NA_TEST_COMMON_EXT_INCLUDE_DEPENDENCIES}
+      ${CXI_INCLUDE_DIRS}
+    )
+    set(NA_TEST_COMMON_EXT_LIB_DEPENDENCIES
+      ${NA_TEST_COMMON_EXT_LIB_DEPENDENCIES}
+      ${CXI_LIBRARIES}
+    )
+  endif()
+endif()
+
 #------------------------------------------------------------------------------
 # Set up test options
 #------------------------------------------------------------------------------
@@ -120,7 +140,7 @@ endif()
 # Mercury test common
 add_library(mercury_test_common STATIC ${MERCURY_TEST_COMMON_SRCS}
   ${MERCURY_TEST_COMMON_PRIVATE_HEADERS})
-target_include_directories(na_test_common
+target_include_directories(mercury_test_common
   PUBLIC  "$<BUILD_INTERFACE:${MERCURY_TEST_COMMON_BUILD_INCLUDE_DEPENDENCIES}>"
 )
 target_include_directories(mercury_test_common

--- a/Testing/common/mercury_test_config.h.in
+++ b/Testing/common/mercury_test_config.h.in
@@ -52,4 +52,7 @@
 /* Define if has <sys/prctl.h> */
 #cmakedefine HG_TEST_HAS_SYSPRCTL_H
 
+/* Define if has <libcxi/libcxi.h> */
+#cmakedefine HG_TEST_HAS_CXI
+
 #endif /* MERCURY_TEST_CONFIG_H */

--- a/Testing/common/na_test.h
+++ b/Testing/common/na_test.h
@@ -10,9 +10,20 @@
 
 #include "na_test_mpi.h"
 
+#ifdef HG_TEST_HAS_CXI
+#    include <libcxi/libcxi.h>
+#endif
+
 /*************************************/
 /* Public Type and Struct Definition */
 /*************************************/
+
+#ifdef HG_TEST_HAS_CXI
+struct na_test_cxi_info {
+    struct cxil_dev *dev;
+    struct cxi_svc_desc svc_desc;
+};
+#endif
 
 struct na_test_info {
     na_class_t *na_class;    /* Default NA class */
@@ -41,6 +52,9 @@ struct na_test_info {
     size_t buf_count;        /* Buffer count */
     bool verbose;            /* Verbose mode */
     struct na_test_mpi_info mpi_info;
+#ifdef HG_TEST_HAS_CXI
+    struct na_test_cxi_info cxi_info;
+#endif
     bool extern_init;    /* Extern init */
     bool use_threads;    /* Use threads */
     bool force_register; /* Force registration each iteration */

--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -148,7 +148,7 @@
       FI_ADDR_STR,                                                             \
       FI_PROGRESS_MANUAL,                                                      \
       FI_PROTO_SHM,                                                            \
-      FI_MULTI_RECV,                                                           \
+      0,                                                                       \
       NA_OFI_HMEM                                                              \
     )                                                                          \
     X(NA_OFI_PROV_SOCKETS,                                                     \
@@ -4242,6 +4242,7 @@ na_ofi_set_domain_ops(
 #else
             (void) na_ofi_domain;
 #endif
+        case NA_OFI_PROV_SHM:
         case NA_OFI_PROV_SOCKETS:
         case NA_OFI_PROV_TCP:
         case NA_OFI_PROV_TCP_RXM:
@@ -4394,6 +4395,7 @@ na_ofi_parse_auth_key(const char *str, enum na_ofi_prov_type prov_type,
             return na_ofi_parse_cxi_auth_key(
                 str, domain_name, &auth_key->cxi_auth_key, auth_key_size_p);
         case NA_OFI_PROV_NULL:
+        case NA_OFI_PROV_SHM:
         case NA_OFI_PROV_SOCKETS:
         case NA_OFI_PROV_TCP:
         case NA_OFI_PROV_TCP_RXM:
@@ -4553,6 +4555,7 @@ na_ofi_parse_auth_key_range(const char *str, enum na_ofi_prov_type prov_type,
             return na_ofi_parse_cxi_auth_key_range(
                 str, &base_key->cxi_auth_key, auth_key_num_p);
         case NA_OFI_PROV_NULL:
+        case NA_OFI_PROV_SHM:
         case NA_OFI_PROV_SOCKETS:
         case NA_OFI_PROV_TCP:
         case NA_OFI_PROV_TCP_RXM:
@@ -4612,6 +4615,7 @@ na_ofi_gen_auth_key(const union na_ofi_auth_key *base_key, int index,
                 &auth_key->cxi_auth_key, auth_key_size_p);
             return NA_SUCCESS;
         case NA_OFI_PROV_NULL:
+        case NA_OFI_PROV_SHM:
         case NA_OFI_PROV_SOCKETS:
         case NA_OFI_PROV_TCP:
         case NA_OFI_PROV_TCP_RXM:


### PR DESCRIPTION
Requires libfabric >= 1.20

Add support for FI_AV_USER_ID

Add support for new CXI address format

Clean up handling of FI_SOURCE_ERR

Separate opening of AV and auth key insertion

Parse auth key range when listening (w/ FI_AV_AUTH_KEY)

Encode/decode auth key when serializing addrs