### PR TITLE
HG: associate handle to HG proc

### DIFF
--- a/src/mercury.c
+++ b/src/mercury.c
@@ -289,9 +289,11 @@ hg_handle_create(struct hg_private_class *hg_class)
     /* CRC32 is enough for small size buffers */
     ret = hg_proc_create((hg_class_t *) hg_class, hash, &hg_handle->in_proc);
     HG_CHECK_SUBSYS_HG_ERROR(rpc, error, ret, "Cannot create HG proc");
+    hg_proc_set_handle(hg_handle->in_proc, &hg_handle->handle);
 
     ret = hg_proc_create((hg_class_t *) hg_class, hash, &hg_handle->out_proc);
     HG_CHECK_SUBSYS_HG_ERROR(rpc, error, ret, "Cannot create HG proc");
+    hg_proc_set_handle(hg_handle->out_proc, &hg_handle->handle);
 
     return hg_handle;
 

--- a/src/mercury_proc.h
+++ b/src/mercury_proc.h
@@ -257,6 +257,26 @@ static HG_INLINE hg_class_t *
 hg_proc_get_class(hg_proc_t proc);
 
 /**
+ * Associate an HG handle with the processor.
+ *
+ * \param proc [IN]             abstract processor object
+ * \param handle [IN]           HG handle
+ *
+ */
+static HG_INLINE void
+hg_proc_set_handle(hg_proc_t proc, hg_handle_t handle);
+
+/**
+ * Get the HG handle associated to the processor.
+ *
+ * \param proc [IN]             abstract processor object
+ *
+ * \return HG handle
+ */
+static HG_INLINE hg_handle_t
+hg_proc_get_handle(hg_proc_t proc);
+
+/**
  * Get the operation type associated to the processor.
  *
  * \param proc [IN]             abstract processor object
@@ -588,6 +608,7 @@ struct hg_proc {
     struct hg_proc_buf proc_buf;
     struct hg_proc_buf extra_buf;
     hg_class_t *hg_class; /* HG class */
+    hg_handle_t handle;   /* HG handle */
     struct hg_proc_buf *current_buf;
 #ifdef HG_HAS_CHECKSUMS
     struct mchecksum_object *checksum; /* Checksum */
@@ -603,6 +624,20 @@ static HG_INLINE hg_class_t *
 hg_proc_get_class(hg_proc_t proc)
 {
     return ((struct hg_proc *) proc)->hg_class;
+}
+
+/*---------------------------------------------------------------------------*/
+static HG_INLINE void
+hg_proc_set_handle(hg_proc_t proc, hg_handle_t handle)
+{
+    ((struct hg_proc *) proc)->handle = handle;
+}
+
+/*---------------------------------------------------------------------------*/
+static HG_INLINE hg_handle_t
+hg_proc_get_handle(hg_proc_t proc)
+{
+    return ((struct hg_proc *) proc)->handle;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
hg_proc_get_handle() can be used to retrieve handle from proc