### PR TITLE
HG Core: add copy_on_multi_recv and multi_recv_copy_threshold

### DIFF
--- a/src/mercury_core_types.h
+++ b/src/mercury_core_types.h
@@ -110,6 +110,13 @@ struct hg_init_info {
      * existing buffers from being reposted.
      * Default value is: 4 */
     unsigned int multi_recv_op_max;
+
+    /* Controls when we should start copying data in an effort to release
+     * multi-recv buffers. Copy will occur when at most
+     * multi_recv_copy_threshold buffers remain. Value should not exceed
+     * multi_recv_op_max.
+     * Default value is: 0 (never copy) */
+    unsigned int multi_recv_copy_threshold;
 };
 
 /* Error return codes:
@@ -204,7 +211,8 @@ typedef enum {
         .sm_info_string = NULL, .checksum_level = HG_CHECKSUM_NONE,            \
         .no_bulk_eager = false, .no_loopback = false, .stats = false,          \
         .no_multi_recv = false, .release_input_early = false,                  \
-        .no_overflow = false, .multi_recv_op_max = 0                           \
+        .no_overflow = false, .multi_recv_op_max = 0,                          \
+        .multi_recv_copy_threshold = 0                                         \
     }
 
 #endif /* MERCURY_CORE_TYPES_H */

--- a/src/mercury_private.h
+++ b/src/mercury_private.h
@@ -171,7 +171,8 @@ hg_init_info_dup_2_3(
         .release_input_early = old_info->release_input_early,
         .traffic_class = NA_TC_UNSPEC,
         .no_overflow = false,
-        .multi_recv_op_max = 0};
+        .multi_recv_op_max = 0,
+        .multi_recv_copy_threshold = 0};
 }
 
 /*---------------------------------------------------------------------------*/
@@ -193,7 +194,8 @@ hg_init_info_dup_2_2(
         .release_input_early = false,
         .traffic_class = NA_TC_UNSPEC,
         .no_overflow = false,
-        .multi_recv_op_max = 0};
+        .multi_recv_op_max = 0,
+        .multi_recv_copy_threshold = 0};
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use these two new parameters to fallback to memcpy to prevent starvation of multi-recv buffers and potential deadlock situations.