### PR TITLE
HG: add HG_BULK_NO_CONNECT op flag

### DIFF
--- a/src/mercury_types.h
+++ b/src/mercury_types.h
@@ -50,8 +50,10 @@ struct hg_bulk_attr {
  * Bulk transfer operators.
  */
 typedef enum hg_bulk_op {
-    HG_BULK_PUSH, /*!< push data to origin */
-    HG_BULK_PULL  /*!< pull data from origin */
+    HG_BULK_PUSH,      /*!< push data to origin */
+    HG_BULK_PULL,      /*!< pull data from origin */
+    HG_BULK_NO_CONNECT /*!< for transports emulating RMA, do not attempt to
+                          connect */
 } hg_bulk_op_t;
 
 /* Callback info structs */

--- a/src/na/na_bmi.c
+++ b/src/na/na_bmi.c
@@ -422,7 +422,7 @@ static na_return_t
 na_bmi_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* get */
@@ -430,7 +430,7 @@ static na_return_t
 na_bmi_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* poll */
@@ -2061,7 +2061,7 @@ na_bmi_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     struct na_bmi_op_id *na_bmi_op_id = (struct na_bmi_op_id *) op_id;
     struct na_bmi_mem_handle *na_bmi_mem_handle_local =
@@ -2193,7 +2193,7 @@ na_bmi_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     struct na_bmi_op_id *na_bmi_op_id = (struct na_bmi_op_id *) op_id;
     struct na_bmi_mem_handle *na_bmi_mem_handle_local =

--- a/src/na/na_mpi.c
+++ b/src/na/na_mpi.c
@@ -332,7 +332,7 @@ static na_return_t
 na_mpi_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* get */
@@ -340,7 +340,7 @@ static na_return_t
 na_mpi_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* poll */
@@ -1613,7 +1613,7 @@ na_mpi_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     struct na_mpi_mem_handle *mpi_local_mem_handle =
         (struct na_mpi_mem_handle *) local_mem_handle;
@@ -1709,7 +1709,7 @@ na_mpi_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     struct na_mpi_mem_handle *mpi_local_mem_handle =
         (struct na_mpi_mem_handle *) local_mem_handle;

--- a/src/na/na_psm.c
+++ b/src/na/na_psm.c
@@ -369,7 +369,7 @@ na_psm_op_destroy(na_class_t *na_class, na_op_id_t *op_id);
  *
  * note: the psm library timeouts do not sleep, they spin in a poll loop
  */
-#define SEC_TO_NSEC(X) ((X) *1000000000LL)
+#define SEC_TO_NSEC(X) ((X) * 1000000000LL)
 
 /*
  * psm_enc64: break a uint64 up into two uint32s and encode each in network
@@ -2160,7 +2160,7 @@ na_psm_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     struct na_psm_class *pc;
     struct na_psm_addr *naddr;
@@ -2339,7 +2339,7 @@ na_psm_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     struct na_psm_class *pc;
     struct na_psm_addr *naddr;

--- a/src/na/na_sm.c
+++ b/src/na/na_sm.c
@@ -1048,7 +1048,7 @@ static NA_INLINE na_return_t
 na_sm_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* get */
@@ -1056,7 +1056,7 @@ static NA_INLINE na_return_t
 na_sm_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* poll_get_fd */
@@ -5012,7 +5012,7 @@ na_sm_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     return na_sm_rma(NA_SM_CLASS(na_class), context, NA_CB_PUT, callback, arg,
         na_sm_process_vm_writev, (struct na_sm_mem_handle *) local_mem_handle,
@@ -5027,7 +5027,7 @@ na_sm_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     return na_sm_rma(NA_SM_CLASS(na_class), context, NA_CB_GET, callback, arg,
         na_sm_process_vm_readv, (struct na_sm_mem_handle *) local_mem_handle,

--- a/src/na/na_types.h
+++ b/src/na/na_types.h
@@ -249,6 +249,9 @@ typedef void (*na_cb_t)(const struct na_cb_info *callback_info);
 #define NA_MEM_WRITE_ONLY 0x02
 #define NA_MEM_READWRITE  0x03
 
+/* RMA optional flags */
+#define NA_RMA_NO_CONNECT (1 << 0)
+
 /* Progress modes */
 #define NA_NO_BLOCK 0x01 /*!< no blocking progress */
 #define NA_NO_RETRY 0x02 /*!< no retry of operations in progress */

--- a/src/na/na_ucx.c
+++ b/src/na/na_ucx.c
@@ -884,7 +884,7 @@ static na_return_t
 na_ucx_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* get */
@@ -892,7 +892,7 @@ static na_return_t
 na_ucx_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
-    size_t length, na_addr_t *remote_addr, uint8_t remote_id,
+    size_t length, na_addr_t *remote_addr, uint8_t remote_id, uint8_t flags,
     na_op_id_t *op_id);
 
 /* poll_get_fd */
@@ -4219,7 +4219,7 @@ na_ucx_put(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     return na_ucx_rma(NA_UCX_CLASS(na_class), context, NA_CB_PUT, callback, arg,
         (struct na_ucx_mem_handle *) local_mem_handle, local_offset,
@@ -4233,7 +4233,7 @@ na_ucx_get(na_class_t *na_class, na_context_t *context, na_cb_t callback,
     void *arg, na_mem_handle_t *local_mem_handle, na_offset_t local_offset,
     na_mem_handle_t *remote_mem_handle, na_offset_t remote_offset,
     size_t length, na_addr_t *remote_addr, uint8_t NA_UNUSED remote_id,
-    na_op_id_t *op_id)
+    uint8_t NA_UNUSED flags, na_op_id_t *op_id)
 {
     return na_ucx_rma(NA_UCX_CLASS(na_class), context, NA_CB_GET, callback, arg,
         (struct na_ucx_mem_handle *) local_mem_handle, local_offset,


### PR DESCRIPTION
NA: update NA_Put/NA_Get() to pass optional flags

NA OFI: update to use FI_TCP_NO_CONNECT flag to prevent connection on RMA. This is to prevent potential connection timeouts when RMA target operates behind a firewall and connection cannot be established.