### PR TITLE
fix hg_proc_save_ptr() error handling and allocation (when using XDR)

### DIFF
--- a/src/mercury_proc_bulk.c
+++ b/src/mercury_proc_bulk.c
@@ -89,6 +89,8 @@ hg_proc_hg_bulk_t(hg_proc_t proc, void *data)
                 hg_proc_bytes(proc, cached_ptr, buf_size);
             } else {
                 buf = hg_proc_save_ptr(proc, buf_size);
+                HG_CHECK_SUBSYS_ERROR(proc, buf == NULL, error, ret, HG_NOMEM,
+                    "Proc save ptr failed to alloc bulk handle enc memory");
                 ret = HG_Bulk_serialize(buf, buf_size, flags, *bulk_ptr);
                 HG_CHECK_SUBSYS_HG_ERROR(
                     proc, error, ret, "Could not serialize handle");
@@ -113,6 +115,8 @@ hg_proc_hg_bulk_t(hg_proc_t proc, void *data)
             }
 
             buf = hg_proc_save_ptr(proc, buf_size);
+            HG_CHECK_SUBSYS_ERROR(proc, buf == NULL, error, ret, HG_NOMEM,
+                "Proc save ptr failed to alloc bulk handle dec memory");
             ret = HG_Bulk_deserialize(hg_class, bulk_ptr, buf, buf_size);
             HG_CHECK_SUBSYS_HG_ERROR(
                 proc, error, ret, "Could not deserialize handle");


### PR DESCRIPTION
hg_proc_hg_bulk_t() uses hg_proc_save_ptr() to allocate buffer space for encoding/decoding bulk handles, but it does not check the return value of hg_proc_save_ptr(). hg_proc_save_ptr() returns NULL on memory allocation failure. update hg_proc_hg_bulk_t() to check the return value of hg_proc_save_ptr() to see if it is NULL.

Update hg_proc_save_ptr():

When hg_proc_save_ptr() is compiled with !HG_HAS_XDR we should check the return value of hg_proc_set_size() for resize errors and fail if hg_proc_set_size() fails.

When hg_proc_save_ptr() is compiled with HG_HAS_XDR, we should follow the XDR BYTES_PER_XDR_UNIT rounding rules just in case the size is not a multiple of BYTES_PER_XDR_UNIT. If we run out of preallocated space we should fail (since XDR does not grow buffers).  Simplify code to use xdr_inline() to allocate memory rather than using xdr_getpos()/xdr_setpos(). Sanity check return value of xdr_inline() to ensure that it is in sync with the initial value of hg_proc->current_buf->buf_ptr.