### PR TITLE
HG proc: enable proc overflow for the HG_HAS_XDR case

### DIFF
--- a/Testing/unit/hg/test_bulk.c
+++ b/Testing/unit/hg/test_bulk.c
@@ -460,7 +460,6 @@ main(int argc, char *argv[])
      * Over-segmented RPC bulk tests.
      *************************************************************************/
 
-#ifndef HG_HAS_XDR
     /* Create bulk info */
     hg_ret =
         hg_test_bulk_create(info.hg_class, 1024, buf_size / 1024, &bulk_info);
@@ -496,7 +495,6 @@ main(int argc, char *argv[])
     HG_TEST_CHECK_HG_ERROR(error, hg_ret, "hg_test_bulk_forward() failed (%s)",
         HG_Error_to_string(hg_ret));
     HG_PASSED();
-#endif
 
     /* Destroy bulk info */
     hg_ret = hg_test_bulk_destroy(&bulk_info);


### PR DESCRIPTION
Modify mercury proc code to use the same buffer management strategy for overflow in the HG_HAS_XDR case that we use in the non-xdr case.  To do this, we modify hg_proc_set_size() to sync the two fields in the XDR structure used by xdrmem with the hg_proc when the extra_buf info is updated.

Update xdr to use the normal version of HG_PROC_CHECK_SIZE() that calls hg_proc_set_size() if needed.

Update hg_proc_save_ptr() to call hg_proc_set_size() in the HG_HAS_XDR case when there is an overflow.

Enable overflow testing in Testing/unit/hg for HG_HAS_XDR (expected size calculations in the xdr case still must account for the xdr size rounding rules).

Additional cleanups:
 - move XDR from hg_proc_buf struct to hg_proc struct (only one XDR is needed, the second one was never used).

 - hg_proc_reset() does not need the buffer pointer and length for the HG_FREE/XDR_FREE case.  Remove un-needed code in hg_free_struct() that was providing it.