### PR TITLE
HG/NA Perf: add spin_flag to prevent from excessively sleeping

### DIFF
--- a/Testing/perf/hg/mercury_perf.h
+++ b/Testing/perf/hg/mercury_perf.h
@@ -55,7 +55,9 @@ struct hg_perf_class_info {
     size_t buf_size_max;
     hg_bulk_t *local_bulk_handles;
     hg_bulk_t *remote_bulk_handles;
-    int wait_fd; /* Wait fd */
+    int wait_fd;             /* Wait fd */
+    hg_time_t spin_deadline; /* Spin deadline */
+    bool spin_flag;          /* Spin flag */
     int class_id;
     bool done;
     bool verify;

--- a/Testing/perf/na/na_perf.c
+++ b/Testing/perf/na/na_perf.c
@@ -56,19 +56,45 @@ na_perf_request_wait(struct na_perf_info *info,
     do {
         unsigned int count = 0, actual_count = 0;
 
-        if (info->poll_set && NA_Poll_try_wait(info->na_class, info->context)) {
-            struct hg_poll_event poll_event = {.events = 0, .data.ptr = NULL};
-            unsigned int actual_events = 0;
-            int rc;
+        if (info->poll_set && timeout_ms != 0) {
+            if (!hg_time_less(now, info->spin_deadline)) {
+                /* Reached spin deadline, reset to force re-evaluation */
+                info->spin_flag = false;
+                info->spin_deadline = hg_time_from_ms(0);
+            }
 
-            NA_TEST_LOG_DEBUG("Waiting for %u ms",
-                hg_time_to_ms(hg_time_subtract(deadline, now)));
+            if (!info->spin_flag) {
+                if (NA_Poll_try_wait(info->na_class, info->context)) {
+                    struct hg_poll_event poll_event = {
+                        .events = 0, .data.ptr = NULL};
+                    unsigned int actual_events = 0;
+                    int rc;
 
-            rc = hg_poll_wait(info->poll_set,
-                hg_time_to_ms(hg_time_subtract(deadline, now)), 1, &poll_event,
-                &actual_events);
-            NA_TEST_CHECK_ERROR(rc != 0, error, ret, NA_PROTOCOL_ERROR,
-                "hg_poll_wait() failed");
+                    NA_TEST_LOG_DEBUG("Waiting for %u ms",
+                        hg_time_to_ms(hg_time_subtract(deadline, now)));
+
+                    rc = hg_poll_wait(info->poll_set,
+                        hg_time_to_ms(hg_time_subtract(deadline, now)), 1,
+                        &poll_event, &actual_events);
+                    NA_TEST_CHECK_ERROR(rc != 0, error, ret, NA_PROTOCOL_ERROR,
+                        "hg_poll_wait() failed");
+                    if (actual_events > 0) {
+                        /* If we woke up with an event, set spin flag to true to
+                         * keep spinning for a while until we reach
+                         * spin_deadline or deadline/timeout. */
+                        hg_time_get_current_ms(&now);
+                        info->spin_flag = true;
+                        info->spin_deadline =
+                            hg_time_add(now, hg_time_from_ms(1000));
+                    }
+                } else {
+                    /* If we did not block, set spin flag to true to keep
+                     * spinning until we reach spin_deadline. */
+                    info->spin_flag = true;
+                    info->spin_deadline =
+                        hg_time_add(now, hg_time_from_ms(1000));
+                }
+            }
         }
 
         ret = NA_Poll(info->na_class, info->context, &count);

--- a/Testing/perf/na/na_perf.h
+++ b/Testing/perf/na/na_perf.h
@@ -47,6 +47,8 @@ struct na_perf_info {
     size_t rma_size_max;              /* Max buffer size */
     size_t rma_count;                 /* Buffer count */
     int poll_fd;                      /* Poll fd */
+    hg_time_t spin_deadline;          /* Spin deadline */
+    bool spin_flag;                   /* Spin flag */
 };
 
 struct na_perf_request_info {

--- a/Testing/perf/na/na_perf_server.c
+++ b/Testing/perf/na/na_perf_server.c
@@ -76,17 +76,46 @@ na_perf_loop(struct na_perf_info *info, na_perf_recv_op_t recv_op,
     while (!recv_info.done) {
         unsigned int count = 0, actual_count = 0;
 
-        if (info->poll_set && NA_Poll_try_wait(info->na_class, info->context)) {
-            struct hg_poll_event poll_event = {.events = 0, .data.ptr = NULL};
-            unsigned int actual_events = 0;
-            int rc;
+        if (info->poll_set) {
+            hg_time_t now;
 
-            NA_TEST_LOG_DEBUG("Waiting for 1000 ms");
+            hg_time_get_current_ms(&now);
+            if (!hg_time_less(now, info->spin_deadline)) {
+                /* Reached spin deadline, reset to force re-evaluation */
+                info->spin_flag = false;
+                info->spin_deadline = hg_time_from_ms(0);
+            }
 
-            rc = hg_poll_wait(
-                info->poll_set, 1000, 1, &poll_event, &actual_events);
-            NA_TEST_CHECK_ERROR(rc != 0, error, ret, NA_PROTOCOL_ERROR,
-                "hg_poll_wait() failed");
+            if (!info->spin_flag) {
+                if (NA_Poll_try_wait(info->na_class, info->context)) {
+                    struct hg_poll_event poll_event = {
+                        .events = 0, .data.ptr = NULL};
+                    unsigned int actual_events = 0;
+                    int rc;
+
+                    NA_TEST_LOG_DEBUG("Waiting for 1000 ms");
+
+                    rc = hg_poll_wait(
+                        info->poll_set, 1000, 1, &poll_event, &actual_events);
+                    NA_TEST_CHECK_ERROR(rc != 0, error, ret, NA_PROTOCOL_ERROR,
+                        "hg_poll_wait() failed");
+                    if (actual_events > 0) {
+                        /* If we woke up with an event, set spin flag to true to
+                         * keep spinning for a while until we reach
+                         * spin_deadline. */
+                        hg_time_get_current_ms(&now);
+                        info->spin_flag = true;
+                        info->spin_deadline =
+                            hg_time_add(now, hg_time_from_ms(1000));
+                    }
+                } else {
+                    /* If we did not block, set spin flag to true to keep
+                     * spinning until we reach spin_deadline. */
+                    info->spin_flag = true;
+                    info->spin_deadline =
+                        hg_time_add(now, hg_time_from_ms(1000));
+                }
+            }
         }
 
         ret = NA_Poll(info->na_class, info->context, &count);


### PR DESCRIPTION
Reduce overhead of hg_poll_wait() in HG/NA perf benchmarks