### PR TITLE
NA OFI: restore IPv6 address family after deserialization

### DIFF
--- a/src/na/na_ofi.c
+++ b/src/na/na_ofi.c
@@ -3141,6 +3141,8 @@ na_ofi_raw_addr_deserialize(int addr_format, union na_ofi_raw_addr *addr,
             size_t buf_size_left = (size_t) buf_size;
 
             memset(&addr->sin6, 0, sizeof(addr->sin6));
+            /* Address family is implicit in addr_format and not serialized. */
+            addr->sin6.sin6_family = AF_INET6;
             NA_DECODE(error, ret, buf_ptr, buf_size_left, &addr->sin6.sin6_addr,
                 struct in6_addr);
             NA_DECODE(error, ret, buf_ptr, buf_size_left, &addr->sin6.sin6_port,


### PR DESCRIPTION
## Summary

Restore `sin6_family = AF_INET6` after clearing the destination `sockaddr_in6` in `na_ofi_raw_addr_deserialize()`.

The raw IPv6 wire format serializes only the address and port because `addr_format` already identifies the family. The current `memset()` therefore leaves the reconstructed address as `AF_UNSPEC`, causing libfabric address validation and `fi_av_insert()` to reject an otherwise valid IPv6 destination.

## Testing Done

Built Mercury v2.4.1 with OFI enabled and this fix, then validated it in a five-host, ten-rank DAOS IPv6/RoCEv2 cluster. All ranks remained joined, pool create/list operations completed successfully, and the previous `fi_av_insert`/protocol errors did not recur.